### PR TITLE
Add last answer modal and selection answer trigger

### DIFF
--- a/RESUELV1/popup.js
+++ b/RESUELV1/popup.js
@@ -110,6 +110,7 @@ async function handleMode(mode){
     if (!gen?.ok) throw new Error(gen?.error||'Generate failed');
     const answer = postProcess(mode, gen.result);
     els.preview.value = answer;
+    await chrome.storage.local.set({ lastAnswer: answer });
     await saveContext({ q: questionText, a: answer });
     renderHistory(await getContext());
     notify('Ready');


### PR DESCRIPTION
## Summary
- Add storage of generated answers and expose "Write Last Answer"/"Clear AI Context" in floating bubble menu
- Support writing answers with a 3 second countdown and selection-triggered "Generate Answer" button
- Persist last answer from popup for reuse in page actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2fb7119e083249b7dde2fb7c63085