### PR TITLE
Use mail.tm API for temporary email in RESUELV2

### DIFF
--- a/RESUELV2/manifest.json
+++ b/RESUELV2/manifest.json
@@ -30,7 +30,8 @@
     "scripting",
     "tabs",
     "contextMenus",
-    "notifications"
+    "notifications",
+    "alarms"
   ],
   "web_accessible_resources": [{
     "resources": ["icons/*"],
@@ -44,7 +45,7 @@
     "https://generativelanguage.googleapis.com/*",
     "https://api.cerebras.ai/*",
     "https://api.ipdata.co/*",
-    "https://www.1secmail.com/*",
+    "https://api.mail.tm/*",
     "https://randomuser.me/*"
   ],
   "background": {


### PR DESCRIPTION
## Summary
- persist temporary mailboxes for 7 days using chrome.storage and mail.tm
- poll mail.tm via background alarms and notify on new messages
- add countdown timer, extend button, and auto-updating inbox UI

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_68b5d9b0c33c8324b58ab47fa9ad7b8b