### PR TITLE
feat: add custom web and firebase login gating

### DIFF
--- a/RESUELV2/content.js
+++ b/RESUELV2/content.js
@@ -5,7 +5,9 @@
 // - Type text into focused field (no humanize; speed only)
 // - Floating bubble with rainbow modal
 
-(() => {
+function init() {
+  if (window.resuelvInit) return;
+  window.resuelvInit = true;
   const STATE = {
     overlay: null,
     rectEl: null,
@@ -216,6 +218,10 @@
             <span class="menu-icon">📧</span>
             <span class="menu-text">Temp Mail</span>
           </div>
+          <div class="menu-item" data-action="custom-web">
+            <span class="menu-icon">🌐</span>
+            <span class="menu-text">Custom Web</span>
+          </div>
         </div>
       </div>
     `;
@@ -383,7 +389,10 @@
         showFakeInfoModal();
         break;
       case 'temp-mail':
-        showTempMailModal();
+        window.open('https://yopmail.com/', '_blank');
+        break;
+      case 'custom-web':
+        await chrome.runtime.sendMessage({ type: 'OPEN_CUSTOM_WEB' });
         break;
     }
   }
@@ -490,107 +499,6 @@
     }
 
     modal.querySelector('#fiGenerate').addEventListener('click', () => generate(false));
-  }
-
-  async function showTempMailModal() {
-    const API_URL = 'https://www.1secmail.com/api/v1';
-    let currentMailbox = null;
-    let refreshTimer = null;
-    const seen = new Set();
-    const modal = createStyledModal('Temporary Email', `
-      <div style="display:flex; gap:10px; flex-wrap:wrap; margin-bottom:10px;">
-        <button id="tmCreate" style="background:linear-gradient(45deg,#4ecdc4,#44a08d); border:none; color:#fff; padding:6px 12px; border-radius:6px; cursor:pointer;">Create</button>
-        <input id="tmEmail" type="text" readonly style="flex:1; padding:6px; border-radius:6px; background:#0b1220; color:#e2e8f0; border:1px solid #334155;" />
-        <button id="tmCopy" style="background:#22c55e;border:none;color:#fff;padding:6px 12px;border-radius:6px;cursor:pointer;">Copy</button>
-      </div>
-      <div style="display:flex; gap:10px; margin-bottom:10px;">
-        <button id="tmRefresh" style="background:linear-gradient(45deg,#ff9ff3,#feca57); border:none; color:#fff; padding:6px 12px; border-radius:6px; cursor:pointer;">Refresh Inbox</button>
-        <button id="tmDelete" style="background:#dc2626;border:none;color:#fff;padding:6px 12px;border-radius:6px;cursor:pointer;">Delete</button>
-      </div>
-      <div id="tmStatus" style="color:#e2e8f0;margin-bottom:10px;"></div>
-      <div id="tmMessages" style="max-height:200px; overflow-y:auto;"></div>
-    `);
-
-    const emailEl = modal.querySelector('#tmEmail');
-    const statusEl = modal.querySelector('#tmStatus');
-    const listEl = modal.querySelector('#tmMessages');
-
-    function setStatus(msg, err=false){
-      if (statusEl) { statusEl.textContent = msg; statusEl.style.color = err ? '#f87171' : '#e2e8f0'; }
-    }
-    function clearMailbox(){
-      currentMailbox = null;
-      emailEl.value = '';
-      listEl.innerHTML = '';
-      if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
-    }
-    async function generateTempEmail(){
-      setStatus('Generating...');
-      try{
-        const res = await fetch(`${API_URL}/?action=genRandomMailbox&count=1`);
-        if(!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        const email = Array.isArray(data) ? data[0] : null;
-        if(email){
-          const [login, domain] = email.split('@');
-          currentMailbox = {login, domain};
-          emailEl.value = email;
-          setStatus('Email generated');
-          seen.clear();
-          await checkInbox();
-          if(refreshTimer) clearInterval(refreshTimer);
-          refreshTimer = setInterval(checkInbox, 60000);
-        }else throw new Error('Invalid response');
-      }catch(e){
-        setStatus('Error: '+e.message, true);
-      }
-    }
-    async function checkInbox(){
-      if(!currentMailbox){ setStatus('No email generated'); return; }
-      try{
-        const {login, domain} = currentMailbox;
-        const res = await fetch(`${API_URL}/?action=getMessages&login=${login}&domain=${domain}`);
-        if(!res.ok) throw new Error(`HTTP ${res.status}`);
-        const msgs = await res.json();
-        renderMessages(msgs);
-        for(const m of msgs){
-          if(!seen.has(m.id)){
-            seen.add(m.id);
-            chrome.runtime.sendMessage({ type: 'SHOW_NOTIFICATION', title: m.from || 'Temp Mail', message: m.subject || '' });
-          }
-        }
-        setStatus(`Found ${msgs.length} message(s).`);
-      }catch(e){
-        setStatus('Error: '+e.message, true);
-      }
-    }
-    function renderMessages(msgs){
-      if(!msgs.length){ listEl.textContent = 'No messages'; return; }
-      listEl.innerHTML = msgs.map(m=>`<div class="tm-msg" data-id="${m.id}" style="padding:6px; border-bottom:1px solid #334155; cursor:pointer;">
-        <div><strong>${m.from || 'Unknown'}</strong></div>
-        <div>${m.subject || ''}</div>
-        <div style=\"font-size:12px; color:#94a3b8;\">${m.date || ''}</div>
-      </div>`).join('');
-      listEl.querySelectorAll('.tm-msg').forEach(div=>div.addEventListener('click',async()=>{
-        const id = div.getAttribute('data-id');
-        try{
-          const {login, domain} = currentMailbox;
-          const res = await fetch(`${API_URL}/?action=readMessage&login=${login}&domain=${domain}&id=${id}`);
-          if(!res.ok) throw new Error(`HTTP ${res.status}`);
-          const msg = await res.json();
-          const body = msg.textBody || msg.body || msg.htmlBody || '';
-          createStyledModal('Mail from '+(msg.from||''), `<div style="max-height:300px;overflow:auto;white-space:pre-wrap;color:#e2e8f0;">${body}</div>
-            <div style="text-align:center;margin-top:10px;"><a href="data:text/plain;charset=utf-8,${encodeURIComponent(body)}" download="mail.txt" style="color:#22c55e;">Download</a></div>`);
-        }catch(err){
-          setStatus('Error: '+err.message, true);
-        }
-      }));
-    }
-
-    modal.querySelector('#tmCreate').addEventListener('click', generateTempEmail);
-    modal.querySelector('#tmRefresh').addEventListener('click', checkInbox);
-    modal.querySelector('#tmCopy').addEventListener('click', ()=>{ if(emailEl.value){ navigator.clipboard.writeText(emailEl.value); showNotification('Email copied'); }});
-    modal.querySelector('#tmDelete').addEventListener('click', ()=>{ clearMailbox(); setStatus('Mailbox cleared'); });
   }
 
   function showLastAnswerModal(answer) {
@@ -1515,4 +1423,11 @@
   `;
   document.head.appendChild(globalStyle);
 
-})();
+}
+
+chrome.storage.local.get('loggedIn', ({ loggedIn }) => {
+  if (loggedIn) init();
+});
+chrome.storage.onChanged.addListener((chg, area) => {
+  if (area === 'local' && chg.loggedIn?.newValue) init();
+});

--- a/RESUELV2/custom_web.html
+++ b/RESUELV2/custom_web.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Custom Sites</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body {
+      margin:0;
+      display:flex;
+      flex-direction:column;
+      height:100vh;
+      background:#181c20;
+      position:relative;
+    }
+
+    /* animated border lights */
+    body::before {
+      content:"";
+      position:fixed;
+      top:0; left:0; right:0; bottom:0;
+      pointer-events:none;
+      padding:3px;
+      border-radius:8px;
+      background:linear-gradient(270deg,#ff0000,#ff7300,#fffb00,#48ff00,#00ffd5,#002bff,#7a00ff,#ff00c8,#ff0000);
+      background-size:1800% 1800%;
+      -webkit-mask:
+        linear-gradient(#000 0 0) content-box,
+        linear-gradient(#000 0 0);
+      -webkit-mask-composite:xor;
+              mask-composite:exclude;
+      animation:borderGlow 10s linear infinite;
+    }
+
+    @keyframes borderGlow {
+      0% { background-position:0% 50%; }
+      50% { background-position:100% 50%; }
+      100% { background-position:0% 50%; }
+    }
+
+    #controls {
+      display:flex;
+      align-items:center;
+      gap:8px;
+      background:#23272b;
+      padding:8px;
+    }
+
+    #siteSelect { flex:1; }
+
+    #container { flex:1; position:relative; }
+
+    #container iframe {
+      position:absolute;
+      top:0; left:0;
+      width:100%; height:100%;
+      border:none;
+    }
+  </style>
+</head>
+<body>
+  <div id="controls">
+    <select id="siteSelect"></select>
+    <button id="writeHereBtn">Write Here</button>
+    <button id="toggleSelect">Hide</button>
+  </div>
+  <div id="container"></div>
+  <script src="custom_web.js"></script>
+</body>
+</html>

--- a/RESUELV2/custom_web.js
+++ b/RESUELV2/custom_web.js
@@ -1,0 +1,74 @@
+const sel = document.getElementById('siteSelect');
+const toggleBtn = document.getElementById('toggleSelect');
+const writeBtn = document.getElementById('writeHereBtn');
+const container = document.getElementById('container');
+
+const params = new URLSearchParams(location.search);
+const targetTabId = Number(params.get('tabId')) || 0;
+
+const frames = {};
+let current = '';
+
+async function init(){
+  const { customSites = [] } = await chrome.storage.local.get('customSites');
+  sel.innerHTML = '<option value="">Select site</option>';
+  customSites.forEach((s)=>{
+    const opt = document.createElement('option');
+    opt.value = s.url;
+    opt.textContent = s.name;
+    sel.appendChild(opt);
+  });
+}
+
+sel.addEventListener('change', ()=>{
+  const val = sel.value;
+  if(!val) return;
+  current = val;
+  if(!frames[val]){
+    const iframe = document.createElement('iframe');
+    iframe.src = val;
+    container.appendChild(iframe);
+    frames[val] = iframe;
+  }
+  for(const [url, frame] of Object.entries(frames)){
+    frame.style.display = (url === val) ? 'block' : 'none';
+  }
+});
+
+toggleBtn.addEventListener('click', ()=>{
+  const hidden = sel.style.display === 'none';
+  sel.style.display = hidden ? '' : 'none';
+  toggleBtn.textContent = hidden ? 'Hide' : 'Show';
+});
+
+writeBtn.addEventListener('click', async ()=>{
+  if(!current) return;
+  const frame = frames[current];
+  if(!frame) return;
+  let text = '';
+  try{
+    text = frame.contentWindow.getSelection().toString();
+  }catch(e){ /* cross-origin */ }
+  if(!text){
+    try{
+      frame.contentWindow.focus();
+      document.execCommand('copy');
+      await new Promise(r=>setTimeout(r,50));
+      text = await navigator.clipboard.readText();
+    }catch(e){ console.error(e); }
+  }
+  if(text && targetTabId){
+    const { typingSpeed='normal' } = await chrome.storage.local.get('typingSpeed');
+    try{ await chrome.tabs.update(targetTabId,{active:true}); }catch{}
+    await chrome.tabs.sendMessage(targetTabId, { type:'TYPE_TEXT', text, options:{ speed: typingSpeed } });
+  }
+});
+
+function saveSize(){
+  chrome.storage.local.set({ customWebSize: { width: window.outerWidth, height: window.outerHeight } });
+}
+
+window.addEventListener('resize', saveSize);
+window.addEventListener('beforeunload', saveSize);
+
+init();

--- a/RESUELV2/login.html
+++ b/RESUELV2/login.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login - Resuelv+</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body {
+      margin: 0;
+      width: 320px;
+      height: 400px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg);
+      color: var(--fg);
+      font-family: 'Segoe UI', Tahoma, sans-serif;
+    }
+    .box {
+      position: relative;
+      width: 100%;
+      max-width: 280px;
+      padding: 40px 30px;
+      background: var(--card);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    .box::before {
+      content: '';
+      position: absolute;
+      inset: -2px;
+      border-radius: inherit;
+      background: linear-gradient(45deg,#ff6b6b,#4ecdc4,#45b7d1,#96ceb4,#feca57,#ff9ff3,#54a0ff);
+      background-size: 400% 400%;
+      animation: borderGlow 6s linear infinite;
+      z-index: -2;
+    }
+    .box::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      padding: 2px;
+      background: conic-gradient(from 0deg,#22c55e,#3b82f6,#a855f7,#22c55e);
+      filter: blur(10px);
+      animation: spin 4s linear infinite;
+      z-index: -1;
+      pointer-events: none;
+    }
+    @keyframes borderGlow {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+    h1 {
+      margin: 0 0 20px;
+      text-align: center;
+      color: var(--accent);
+      font-size: 1.4rem;
+      text-shadow: 0 0 6px var(--accent), 0 0 12px var(--accent);
+      animation: glow 2s ease-in-out infinite alternate;
+    }
+    @keyframes glow {
+      from { text-shadow: 0 0 6px var(--accent), 0 0 12px var(--accent); }
+      to { text-shadow: 0 0 12px var(--accent), 0 0 24px var(--accent); }
+    }
+    input {
+      width: 100%;
+      margin: 8px 0;
+      padding: 10px;
+      border-radius: 6px;
+      border: 1px solid #334155;
+      background: #0b1220;
+      color: var(--fg);
+    }
+    button {
+      width: 100%;
+      margin-top: 10px;
+      padding: 10px;
+      border: none;
+      border-radius: 6px;
+      background: var(--accent);
+      color: #0b1215;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { filter: brightness(1.1); }
+    #loginError {
+      margin-top: 12px;
+      text-align: center;
+      min-height: 20px;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>Resuelv+</h1>
+    <input type="email" id="email" placeholder="Email" />
+    <input type="password" id="password" placeholder="Password" />
+    <button id="loginBtn">Login</button>
+    <div id="loginError"></div>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/RESUELV2/login.js
+++ b/RESUELV2/login.js
@@ -1,0 +1,57 @@
+const firebaseConfig = {
+  apiKey: 'AIzaSyD4tYdVWd5iqtQwZgrQLiG83GIw62hpn1U',
+  authDomain: 'zepra-89473.firebaseapp.com',
+  projectId: 'zepra-89473',
+  storageBucket: 'zepra-89473.firebasestorage.app',
+  messagingSenderId: '868922736037',
+  appId: '1:868922736037:web:d2de6153dff4ca0995fc4c',
+  measurementId: 'G-S6MGNR8G39'
+};
+
+const emailEl = document.getElementById('email');
+const passEl = document.getElementById('password');
+const btn = document.getElementById('loginBtn');
+const msg = document.getElementById('loginError');
+
+// Redirect if already logged in and show any logout message
+chrome.storage.local.get(['loggedIn', 'logoutMsg'], ({ loggedIn, logoutMsg }) => {
+  if (loggedIn) {
+    window.location.href = 'popup.html';
+  } else if (logoutMsg) {
+    msg.textContent = logoutMsg;
+    msg.style.color = 'var(--warn)';
+    chrome.storage.local.remove('logoutMsg');
+  }
+});
+
+btn.addEventListener('click', async () => {
+  const email = emailEl.value.trim();
+  const password = passEl.value;
+  msg.textContent = '';
+  msg.style.color = 'var(--warn)';
+  if (!email || !password) {
+    msg.textContent = 'Please enter email and password';
+    return;
+  }
+  try {
+    const res = await fetch(`https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${firebaseConfig.apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, returnSecureToken: true })
+      });
+    const data = await res.json();
+    if (data.error) throw new Error(data.error.message);
+    await chrome.storage.local.set({
+      loggedIn: true,
+      idToken: data.idToken,
+      refreshToken: data.refreshToken,
+      lastAuthCheck: Date.now()
+    });
+    msg.style.color = 'var(--accent)';
+    msg.textContent = 'Logged in successfully!';
+    setTimeout(() => { window.location.href = 'popup.html'; }, 800);
+  } catch (e) {
+    msg.textContent = 'Invalid email or password';
+  }
+});

--- a/RESUELV2/manifest.json
+++ b/RESUELV2/manifest.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "description": "Survey helper: LLM answers, OCR, and IP info.",
   "action": {
-    "default_popup": "popup.html",
+    "default_popup": "login.html",
     "default_icon": {
       "16": "icons/icon16.png",
       "32": "icons/icon32.png",
@@ -30,7 +30,9 @@
     "scripting",
     "tabs",
     "contextMenus",
-    "notifications"
+    "notifications",
+    "clipboardRead",
+    "clipboardWrite"
   ],
   "web_accessible_resources": [{
     "resources": ["icons/*"],
@@ -44,9 +46,14 @@
     "https://generativelanguage.googleapis.com/*",
     "https://api.cerebras.ai/*",
     "https://api.ipdata.co/*",
-    "https://www.1secmail.com/*",
-    "https://randomuser.me/*"
+    "https://api.mail.tm/*",
+    "https://randomuser.me/*",
+    "https://identitytoolkit.googleapis.com/*",
+    "https://securetoken.googleapis.com/*"
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "background": {
     "service_worker": "background.js"
   },

--- a/RESUELV2/options.html
+++ b/RESUELV2/options.html
@@ -282,6 +282,36 @@
       </table>
     </div>
 
+    <div class="group">
+      <div class="subtitle">Custom Sites</div>
+      <form id="siteForm">
+        <label class="row">
+          <span>Name</span>
+          <input id="siteName" type="text" />
+        </label>
+        <label class="row">
+          <span>URL</span>
+          <input id="siteUrl" type="url" placeholder="https://example.com/" />
+        </label>
+        <div class="row end">
+          <button id="addSite" type="button" class="btn primary">Add</button>
+        </div>
+      </form>
+      <ul id="sitesList" style="list-style:none; padding-left:0; margin-top:10px;"></ul>
+    </div>
+
+    <div class="group">
+      <div class="subtitle">Custom Window Size</div>
+      <label class="row">
+        <span>Width</span>
+        <input id="webWidth" type="number" min="400" />
+      </label>
+      <label class="row">
+        <span>Height</span>
+        <input id="webHeight" type="number" min="300" />
+      </label>
+    </div>
+
     <div class="row end">
       <button id="test" class="btn">Test API</button>
       <button id="save" class="btn primary">Save</button>

--- a/RESUELV2/options.js
+++ b/RESUELV2/options.js
@@ -22,6 +22,12 @@ const els = {
   savePrompt: document.getElementById('savePrompt'),
   cancelPrompt: document.getElementById('cancelPrompt'),
   promptTable: document.getElementById('promptTable')?.querySelector('tbody'),
+  siteName: document.getElementById('siteName'),
+  siteUrl: document.getElementById('siteUrl'),
+  addSite: document.getElementById('addSite'),
+  sitesList: document.getElementById('sitesList'),
+  webWidth: document.getElementById('webWidth'),
+  webHeight: document.getElementById('webHeight'),
 };
 
 function notify(msg, isErr = false) {
@@ -43,6 +49,7 @@ async function load() {
       'ipdataApiKey',
       'typingSpeed',
       'ocrLang',
+      'customWebSize',
     ]);
 
     els.aiProvider.value     = s.aiProvider || 'openrouter';
@@ -54,8 +61,11 @@ async function load() {
     els.ipdataKey.value      = s.ipdataApiKey || '';
     els.typingSpeed.value    = s.typingSpeed || 'normal';
     els.ocrLang.value        = s.ocrLang || 'eng';
+    els.webWidth.value       = s.customWebSize?.width || 1000;
+    els.webHeight.value      = s.customWebSize?.height || 800;
 
     await loadPrompts();
+    await loadSites();
     console.log('Settings loaded successfully');
   } catch (e) {
     console.error('Error loading settings:', e);
@@ -68,6 +78,11 @@ let editingId = null;
 async function loadPrompts() {
   const { customPrompts = [] } = await chrome.storage.sync.get('customPrompts');
   renderPromptTable(customPrompts);
+}
+
+async function loadSites(){
+  const { customSites = [] } = await chrome.storage.local.get('customSites');
+  renderSites(customSites);
 }
 
 function renderPromptTable(list) {
@@ -121,6 +136,28 @@ function renderPromptTable(list) {
   );
 }
 
+function renderSites(list){
+  if(!els.sitesList) return;
+  els.sitesList.innerHTML = '';
+  list.forEach((s, idx) => {
+    const li = document.createElement('li');
+    li.style.display = 'flex';
+    li.style.justifyContent = 'space-between';
+    li.style.alignItems = 'center';
+    li.style.marginBottom = '6px';
+    li.innerHTML = `<span>${s.name}</span><button class="btn small warn" data-del="${idx}">Delete</button>`;
+    els.sitesList.appendChild(li);
+  });
+  els.sitesList.querySelectorAll('button[data-del]').forEach(btn =>
+    btn.addEventListener('click', async e => {
+      const idx = Number(e.currentTarget.getAttribute('data-del'));
+      list.splice(idx,1);
+      await chrome.storage.local.set({customSites: list});
+      renderSites(list);
+    })
+  );
+}
+
 function resetPromptForm() {
   els.promptName.value = '';
   els.promptTags.value = '';
@@ -130,6 +167,18 @@ function resetPromptForm() {
 }
 
 els.cancelPrompt?.addEventListener('click', resetPromptForm);
+
+els.addSite?.addEventListener('click', async () => {
+  const name = els.siteName.value.trim();
+  const url = els.siteUrl.value.trim();
+  if (!name || !url) { notify('Name and URL required', true); return; }
+  const { customSites = [] } = await chrome.storage.local.get('customSites');
+  customSites.push({ name, url });
+  await chrome.storage.local.set({ customSites });
+  els.siteName.value = '';
+  els.siteUrl.value = '';
+  renderSites(customSites);
+});
 
 els.savePrompt?.addEventListener('click', async () => {
   const name = els.promptName.value.trim();
@@ -168,6 +217,10 @@ els.save?.addEventListener('click', async () => {
       ipdataApiKey:      els.ipdataKey.value.trim(),
       typingSpeed:       els.typingSpeed.value,
       ocrLang:           els.ocrLang.value,
+      customWebSize:     {
+        width: Number(els.webWidth.value) || 1000,
+        height: Number(els.webHeight.value) || 800,
+      },
     });
     notify('Saved');
     console.log('Settings saved successfully');

--- a/RESUELV2/popup.html
+++ b/RESUELV2/popup.html
@@ -345,7 +345,10 @@
         <!-- Header -->
         <div class="header">
             <div class="title">Resuelv+</div>
-            <a class="link" id="openOptions">Options</a>
+            <div>
+                <a class="link" id="openCustomWeb" style="margin-right:10px;">Custom Web</a>
+                <a class="link" id="openOptions">Options</a>
+            </div>
         </div>
 
         <!-- Main Action Buttons with Navigation -->

--- a/RESUELV2/popup.js
+++ b/RESUELV2/popup.js
@@ -1,10 +1,18 @@
 // popup.js
+(async () => {
+  const { loggedIn } = await chrome.storage.local.get('loggedIn');
+  if (!loggedIn) { window.location.href = 'login.html'; return; }
+  const res = await chrome.runtime.sendMessage({ type: 'CHECK_AUTH', force: true });
+  if (!res?.ok) { window.location.href = 'login.html'; return; }
+})();
+
 const els = {
   status: document.getElementById('status'),
   preview: document.getElementById('preview'),
   btnWrite: document.getElementById('btnWrite'),
   btnCopy: document.getElementById('btnCopy'),
   openOptions: document.getElementById('openOptions'),
+  openCustomWeb: document.getElementById('openCustomWeb'),
   history: document.getElementById('history'),
   ipInfoText: document.getElementById('ipInfoText'),
   btnCustomPrompt: document.getElementById('btnCustomPrompt'),
@@ -68,6 +76,10 @@ for (const id of Object.keys(btnMap)) {
 updateButtonVisibility();
 
 els.openOptions?.addEventListener('click', () => chrome.runtime.openOptionsPage());
+els.openCustomWeb?.addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({active:true,currentWindow:true});
+  await chrome.runtime.sendMessage({ type:'OPEN_CUSTOM_WEB', openerTabId: tab.id });
+});
 els.viewHistory?.addEventListener('click', () => {
   chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
 });


### PR DESCRIPTION
## Summary
- periodically verify Firebase account status and auto-logout invalid sessions with a session-expired notice
- refresh the login screen with animated glow effects and English messages
- check authentication state whenever the popup loads

## Testing
- `jq '.' RESUELV2/manifest.json`
- `node --check RESUELV2/login.js`
- `node --check RESUELV2/popup.js`
- `node --check RESUELV2/background.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d9b644c88324b3b451b220261928