### PR TITLE
Add custom SOCKS5 proxy handler

### DIFF
--- a/RESUELV1/background.js
+++ b/RESUELV1/background.js
@@ -2,6 +2,10 @@
 // - OpenRouter chat completions
 // - OCR via OCR.space
 // - Public IP via ipapi.co
+// - Proxy control (HTTP/HTTPS via chrome.proxy, SOCKS via native helper)
+
+// Load proxy utilities that expose a global `configureProxy` function.
+importScripts('proxy.js');
 
 const DEFAULTS = {
   openrouterModel: 'google/gemini-2.0-flash-exp:free',
@@ -96,6 +100,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         case 'GET_TAB_ID': {
           const id = sender?.tab?.id || (await getActiveTabId());
           sendResponse({ ok: true, tabId: id });
+          break;
+        }
+        case 'SET_PROXY': {
+          await configureProxy(message.proxy);
+          sendResponse({ ok: true });
           break;
         }
         default:

--- a/RESUELV1/manifest.json
+++ b/RESUELV1/manifest.json
@@ -29,7 +29,11 @@
     "activeTab",
     "scripting",
     "tabs",
-    "contextMenus"
+    "contextMenus",
+    "proxy",
+    "webRequest",
+    "webRequestBlocking",
+    "nativeMessaging"
   ],
   "host_permissions": [
     "https://openrouter.ai/*",

--- a/RESUELV1/proxy.js
+++ b/RESUELV1/proxy.js
@@ -1,0 +1,87 @@
+/**
+ * proxy.js
+ *
+ * Provides a unified interface for configuring proxies. HTTP/HTTPS
+ * proxies continue to use the Chrome proxy settings and
+ * `onAuthRequired` flow. SOCKS5 proxies are handled via a native
+ * messaging host that opens authenticated tunnels on behalf of the
+ * extension. This avoids relying on the deprecated SOCKS handling of
+ * `chrome.proxy.settings`.
+ */
+
+const AUTH_LISTENER_KEY = Symbol('authListener');
+
+/**
+ * Configure a proxy. Passing `null` clears any existing proxy
+ * configuration. Supported schemes: `http`, `https`, `socks5`.
+ *
+ * @param {Object|null} proxy - Proxy configuration.
+ * @param {string} proxy.scheme - Proxy scheme (http, https, socks5).
+ * @param {string} proxy.host - Proxy host name or IP.
+ * @param {number} proxy.port - Proxy port.
+ * @param {string} [proxy.username] - Optional username.
+ * @param {string} [proxy.password] - Optional password.
+ * @param {string} [proxy.destHost] - Destination host for SOCKS tunnel.
+ * @param {number} [proxy.destPort] - Destination port for SOCKS tunnel.
+ */
+self.configureProxy = async function configureProxy(proxy) {
+  if (!proxy) {
+    await clearProxy();
+    return;
+  }
+
+  const scheme = proxy.scheme?.toLowerCase();
+  if (scheme === 'socks5') {
+    // Remove any previous Chrome proxy configuration before opening the
+    // tunnel so normal traffic is unaffected.
+    await clearProxy();
+    await openSocksTunnel(proxy);
+    return;
+  }
+
+  await setupChromeProxy(proxy);
+};
+
+async function setupChromeProxy({ scheme, host, port, username, password }) {
+  const config = {
+    mode: 'fixed_servers',
+    rules: {
+      singleProxy: { scheme, host, port: parseInt(port, 10) }
+    }
+  };
+  chrome.proxy.settings.set({ value: config, scope: 'regular' });
+
+  if (username || password) {
+    const listener = details => ({
+      authCredentials: { username: username || '', password: password || '' }
+    });
+    chrome.webRequest.onAuthRequired.addListener(
+      listener,
+      { urls: ['<all_urls>'] },
+      ['blocking']
+    );
+    self[AUTH_LISTENER_KEY] = listener;
+  }
+}
+
+async function clearProxy() {
+  chrome.proxy.settings.clear({ scope: 'regular' });
+  const listener = self[AUTH_LISTENER_KEY];
+  if (listener && chrome.webRequest.onAuthRequired.hasListener(listener)) {
+    chrome.webRequest.onAuthRequired.removeListener(listener);
+    delete self[AUTH_LISTENER_KEY];
+  }
+}
+
+async function openSocksTunnel({ host, port, username, password, destHost, destPort }) {
+  const message = {
+    type: 'OPEN_SOCKS_TUNNEL',
+    proxy: { host, port, username, password },
+    destination: { host: destHost, port: destPort }
+  };
+  try {
+    await chrome.runtime.sendNativeMessage('com.resuelv.socks', message);
+  } catch (err) {
+    console.error('SOCKS tunnel failed', err);
+  }
+}

--- a/RESUELV2/background.js
+++ b/RESUELV2/background.js
@@ -2,6 +2,11 @@
 // - OpenRouter chat completions
 // - OCR via OCR.space
 // - Public IP via ipdata with fallback services
+// - Proxy control (HTTP/HTTPS via chrome.proxy, SOCKS via native helper)
+
+// Load proxy utilities. The script exposes a global `configureProxy`
+// function used below.
+importScripts('proxy.js');
 
 const DEFAULTS = {
   openrouterModel: 'google/gemini-2.0-flash-exp:free',
@@ -133,6 +138,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           const { gender, nat, force } = message;
           const data = await fetchRandomUser({ gender, nat, force });
           sendResponse({ ok: true, data });
+          break;
+        }
+        case 'SET_PROXY': {
+          await configureProxy(message.proxy);
+          sendResponse({ ok: true });
           break;
         }
         default:

--- a/RESUELV2/manifest.json
+++ b/RESUELV2/manifest.json
@@ -30,7 +30,11 @@
     "scripting",
     "tabs",
     "contextMenus",
-    "notifications"
+    "notifications",
+    "proxy",
+    "webRequest",
+    "webRequestBlocking",
+    "nativeMessaging"
   ],
   "web_accessible_resources": [{
     "resources": ["icons/*"],

--- a/RESUELV2/proxy.js
+++ b/RESUELV2/proxy.js
@@ -1,0 +1,87 @@
+/**
+ * proxy.js
+ *
+ * Provides a unified interface for configuring proxies. HTTP/HTTPS
+ * proxies continue to use the Chrome proxy settings and
+ * `onAuthRequired` flow. SOCKS5 proxies are handled via a native
+ * messaging host that opens authenticated tunnels on behalf of the
+ * extension. This avoids relying on the deprecated SOCKS handling of
+ * `chrome.proxy.settings`.
+ */
+
+const AUTH_LISTENER_KEY = Symbol('authListener');
+
+/**
+ * Configure a proxy. Passing `null` clears any existing proxy
+ * configuration. Supported schemes: `http`, `https`, `socks5`.
+ *
+ * @param {Object|null} proxy - Proxy configuration.
+ * @param {string} proxy.scheme - Proxy scheme (http, https, socks5).
+ * @param {string} proxy.host - Proxy host name or IP.
+ * @param {number} proxy.port - Proxy port.
+ * @param {string} [proxy.username] - Optional username.
+ * @param {string} [proxy.password] - Optional password.
+ * @param {string} [proxy.destHost] - Destination host for SOCKS tunnel.
+ * @param {number} [proxy.destPort] - Destination port for SOCKS tunnel.
+ */
+self.configureProxy = async function configureProxy(proxy) {
+  if (!proxy) {
+    await clearProxy();
+    return;
+  }
+
+  const scheme = proxy.scheme?.toLowerCase();
+  if (scheme === 'socks5') {
+    // Remove any previous Chrome proxy configuration before opening the
+    // tunnel so normal traffic is unaffected.
+    await clearProxy();
+    await openSocksTunnel(proxy);
+    return;
+  }
+
+  await setupChromeProxy(proxy);
+};
+
+async function setupChromeProxy({ scheme, host, port, username, password }) {
+  const config = {
+    mode: 'fixed_servers',
+    rules: {
+      singleProxy: { scheme, host, port: parseInt(port, 10) }
+    }
+  };
+  chrome.proxy.settings.set({ value: config, scope: 'regular' });
+
+  if (username || password) {
+    const listener = details => ({
+      authCredentials: { username: username || '', password: password || '' }
+    });
+    chrome.webRequest.onAuthRequired.addListener(
+      listener,
+      { urls: ['<all_urls>'] },
+      ['blocking']
+    );
+    self[AUTH_LISTENER_KEY] = listener;
+  }
+}
+
+async function clearProxy() {
+  chrome.proxy.settings.clear({ scope: 'regular' });
+  const listener = self[AUTH_LISTENER_KEY];
+  if (listener && chrome.webRequest.onAuthRequired.hasListener(listener)) {
+    chrome.webRequest.onAuthRequired.removeListener(listener);
+    delete self[AUTH_LISTENER_KEY];
+  }
+}
+
+async function openSocksTunnel({ host, port, username, password, destHost, destPort }) {
+  const message = {
+    type: 'OPEN_SOCKS_TUNNEL',
+    proxy: { host, port, username, password },
+    destination: { host: destHost, port: destPort }
+  };
+  try {
+    await chrome.runtime.sendNativeMessage('com.resuelv.socks', message);
+  } catch (err) {
+    console.error('SOCKS tunnel failed', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add proxy utilities that use native messaging for SOCKS5 tunnels while keeping chrome.proxy/onAuthRequired for HTTP/HTTPS
- load proxy helper in background service worker and handle `SET_PROXY` messages
- request proxy, webRequest and nativeMessaging permissions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bec6c1f3e083249ab91de633e7e437