### PR TITLE
refactor: restore classic dashboard and neon modals

### DIFF
--- a/RESUELV2/content.js
+++ b/RESUELV2/content.js
@@ -382,199 +382,232 @@ function init() {
   }
 
   function showBubbleMenu() {
-    if (document.getElementById('zepra-bubble-menu')) return;
-    
-    const menu = document.createElement('div');
-    menu.id = 'zepra-bubble-menu';
+    if (document.getElementById('zepra-sidebar')) return;
+
+    const menu = document.createElement('aside');
+    menu.id = 'zepra-sidebar';
     menu.innerHTML = `
-      <div class="bubble-menu-content">
-        <div class="menu-header">
-          <h3 class="zepra-gradient">Zepra Menu</h3>
-          <button class="close-btn">&times;</button>
+      <div class="zepra-particles"></div>
+      <header class="sidebar-header">
+        <svg class="zap-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        <div class="title-group">
+          <h2>Zepra Menu</h2>
+          <p>Chrome Extension Suite</p>
         </div>
-        <div class="menu-items">
-          <div class="menu-item" data-action="ocr">
-            <span class="menu-icon">📷</span>
-            <span class="menu-text">OCR Capture</span>
-          </div>
-          <div class="menu-item" data-action="ocr-full">
-            <span class="menu-icon">🖼️</span>
-            <span class="menu-text">OCR Full Page</span>
-          </div>
-          <div class="menu-item" data-action="write-last">
-            <span class="menu-icon">✍️</span>
-            <span class="menu-text">Write Last Answer</span>
-          </div>
-          <div class="menu-item" data-action="clear-context">
-            <span class="menu-icon">🧹</span>
-            <span class="menu-text">Clear AI Context</span>
-          </div>
-          <div class="menu-item" data-action="ip-info">
-            <span class="menu-icon">🌐</span>
-            <span class="menu-text">IP Information</span>
-          </div>
-          <div class="menu-item" data-action="ip-qual">
-            <span class="menu-icon">📊</span>
-            <span class="menu-text">IP Qualification</span>
-          </div>
-          <div class="menu-item" data-action="fake-info">
-            <span class="menu-icon">👤</span>
-            <span class="menu-text">Generate Fake Info</span>
-          </div>
-          <div class="menu-item" data-action="temp-mail">
-            <span class="menu-icon">📧</span>
-            <span class="menu-text">Temp Mail</span>
-          </div>
-          <div class="menu-item" data-action="custom-web">
-            <span class="menu-icon">🌐</span>
-            <span class="menu-text">Custom Web</span>
-          </div>
-          <div class="menu-item" data-action="ai-humanizer">
-            <span class="menu-icon">🧠</span>
-            <span class="menu-text">AI Humanizer</span>
-          </div>
-          <div class="menu-item" data-action="real-address">
-            <span class="menu-icon">🏠</span>
-            <span class="menu-text">Generate Real Address</span>
-          </div>
-          <div class="menu-item" data-action="company-info">
-            <span class="menu-icon">🏢</span>
-            <span class="menu-text">Generate Company Info</span>
-          </div>
-          <div class="menu-item" data-action="identity-panel">
-            <span class="menu-icon">📋</span>
-            <span class="menu-text">Show Identity Data</span>
-          </div>
-          <div class="menu-item" data-action="zebra-vps">
-            <span class="menu-icon">💻</span>
-            <span class="menu-text">Zebra VPS</span>
-          </div>
-        </div>
-      </div>
-    `;
-    
-    menu.style.cssText = `
-      position: fixed;
-      top: 90px;
-      right: 20px;
-      width: 250px;
-      background: #000;
-      border-radius: 15px;
-      box-shadow: 0 0 20px rgba(57,255,20,0.3), 0 0 20px rgba(255,230,0,0.3);
-      z-index: 2147483648;
-      animation: slideIn 0.3s ease-out;
-      border: 2px solid #39ff14;
+        <button class="close-btn" aria-label="Close">&times;</button>
+      </header>
+      <nav class="sidebar-nav">
+        <ul>
+          <li><a href="#" data-action="ocr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="12" cy="12" r="3"/></svg><span>OCR Capture</span></a></li>
+          <li><a href="#" data-action="ocr-full"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="16" y1="2" x2="16" y2="6"/></svg><span>OCR Full Page</span></a></li>
+          <li><a href="#" data-action="write-last"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg><span>Write Last Answer</span></a></li>
+          <li><a href="#" data-action="clear-context"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Clear AI Context</span></a></li>
+          <li><a href="#" data-action="ip-info"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg><span>IP Information</span></a></li>
+          <li><a href="#" data-action="ip-qual"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg><span>IP Qualification</span></a></li>
+          <li><a href="#" data-action="fake-info"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="4"/><path d="M5.5 21a7.5 7.5 0 0 1 13 0"/></svg><span>Generate Fake Info</span></a></li>
+          <li><a href="#" data-action="temp-mail"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="22,6 12,13 2,6"/></svg><span>Temp Mail</span></a></li>
+          <li><a href="#" data-action="custom-web"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg><span>Custom Web</span></a></li>
+          <li><a href="#" data-action="ai-humanizer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a7 7 0 0 0-7 7v4a7 7 0 0 0 7 7 7 7 0 0 0 7-7V9a7 7 0 0 0-7-7z"/><path d="M9 9h6"/><path d="M9 13h6"/></svg><span>AI Humanizer</span></a></li>
+          <li><a href="#" data-action="real-address"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7"/><path d="M9 22V12h6v10"/><path d="M9 22H5a2 2 0 0 1-2-2v-7"/><path d="M21 13v7a2 2 0 0 1-2 2h-4"/></svg><span>Generate Real Address</span></a></li>
+          <li><a href="#" data-action="company-info"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M16 3v18"/><path d="M8 3v18"/><path d="M3 8h18"/><path d="M3 16h18"/></svg><span>Generate Company Info</span></a></li>
+          <li><a href="#" data-action="identity-panel"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="10" r="2"/><path d="M15 8h2"/><path d="M15 12h2"/><path d="M7 16h10"/></svg><span>Show Identity Data</span></a></li>
+          <li><a href="#" data-action="zebra-vps"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="8" rx="2"/><rect x="2" y="12" width="20" height="8" rx="2"/><path d="M6 8h.01"/><path d="M6 16h.01"/></svg><span>Zebra VPS</span></a></li>
+        </ul>
+      </nav>
+      <footer class="sidebar-footer">
+        <p>Powered by Advanced AI · Secure & Encrypted</p>
+        <div class="footer-dots"><span></span><span></span><span></span></div>
+      </footer>
     `;
 
     const menuStyle = document.createElement('style');
     menuStyle.textContent = `
-      @keyframes slideIn {
-        from { opacity: 0; transform: translateY(-20px) scale(0.9); }
-        to { opacity: 1; transform: translateY(0) scale(1); }
-      }
-      
-      .bubble-menu-content {
-        padding: 15px;
-        color: #e2e8f0;
-      }
-      
-      .menu-header {
+      #zepra-sidebar {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100vh;
+        width: 100%;
+        max-width: 360px;
+        background-color: rgba(0,0,0,0.8);
+        backdrop-filter: blur(12px);
+        border-left: 1px solid rgba(74,222,128,0.2);
         display: flex;
-        justify-content: space-between;
+        flex-direction: column;
+        transform: translateX(100%);
+        transition: transform 0.4s ease-in-out;
+        z-index: 2147483648;
+        overflow-y: auto;
+      }
+
+      #zepra-sidebar.open { transform: translateX(0); }
+
+      #zepra-sidebar .zepra-particles {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+        z-index: -1;
+      }
+
+      #zepra-sidebar .zepra-particles span {
+        position: absolute;
+        display: block;
+        border-radius: 50%;
+        background: rgba(74,222,128,0.4);
+        animation: float 6s linear infinite;
+      }
+
+      @keyframes float {
+        0% { transform: translateY(0); }
+        50% { transform: translateY(-10px); }
+        100% { transform: translateY(0); }
+      }
+
+      .sidebar-header {
+        display: flex;
         align-items: center;
-        margin-bottom: 15px;
-        border-bottom: 1px solid #292d33;
-        padding-bottom: 10px;
+        justify-content: space-between;
+        padding: 16px;
+        border-bottom: 1px solid rgba(74,222,128,0.2);
       }
-      
-      .menu-header h3 {
+
+      .sidebar-header .title-group { flex: 1; margin-left: 8px; }
+      .sidebar-header h2 {
         margin: 0;
-        font-size: 16px;
-        font-weight: bold;
-        color: #39ff14;
+        font-size: 1.2rem;
+        color: #4ade80;
+        text-shadow: 0 0 8px #4ade80;
       }
-      
+      .sidebar-header p {
+        margin: 2px 0 0;
+        font-size: 0.75rem;
+        color: #94a3b8;
+      }
+      .zap-icon {
+        width: 24px;
+        height: 24px;
+        flex-shrink: 0;
+        color: #4ade80;
+        filter: drop-shadow(0 0 5px #4ade80);
+        animation: pulse 2s infinite;
+      }
+
+      @keyframes pulse {
+        0%,100% { opacity: 1; }
+        50% { opacity: 0.6; }
+      }
+
       .close-btn {
         background: none;
         border: none;
-        color: #e2e8f0;
+        color: #9ca3af;
         font-size: 20px;
         cursor: pointer;
-        padding: 0;
-        width: 25px;
-        height: 25px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: background 0.2s;
+        transition: color 0.2s;
       }
-      
-      .close-btn:hover {
-        background: rgba(255,255,255,0.2);
-      }
-      
-      .menu-items {
+      .close-btn:hover { color: #fff; }
+
+      .sidebar-nav ul {
+        list-style: none;
+        padding: 8px;
+        margin: 0;
         display: flex;
         flex-direction: column;
         gap: 4px;
       }
 
-      .menu-item {
+      .sidebar-nav a {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px;
+        border-radius: 8px;
+        color: #4ade80;
+        text-decoration: none;
+        transition: all 0.2s ease;
+      }
+
+      .sidebar-nav a svg { width: 20px; height: 20px; flex-shrink: 0; }
+
+      .sidebar-nav a::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 3px;
+        background: #4ade80;
+        opacity: 0;
+        box-shadow: 0 0 6px #4ade80;
+        transition: opacity 0.2s;
+      }
+
+      .sidebar-nav a:hover {
+        background-color: rgba(74,222,128,0.1);
+        transform: translateX(5px);
+      }
+      .sidebar-nav a:hover::before { opacity: 1; }
+
+      .sidebar-footer {
+        margin-top: auto;
+        padding: 12px;
+        border-top: 1px solid rgba(74,222,128,0.2);
         display: flex;
         align-items: center;
         gap: 6px;
-        padding: 4px;
-        border-radius: 8px;
-        cursor: pointer;
-        transition: all 0.2s;
-        background: linear-gradient(120deg, #000 60%, #39ff1480 100%);
+        color: #9ca3af;
+        font-size: 0.75rem;
       }
-      
-      .menu-item:hover {
-        background: linear-gradient(120deg, #39ff1499 60%, #ffe600 100%);
-        transform: translateX(5px);
-      }
-      
-      .menu-icon {
-        font-size: 14px;
-        width: 18px;
-        text-align: center;
-      }
-
-      .menu-text {
-        font-size: 13px;
-        font-weight: 500;
-        color: #ffd600;
+      .footer-dots { display: flex; gap: 4px; margin-left: 4px; }
+      .footer-dots span {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: #4ade80;
+        animation: pulse 2s infinite;
       }
     `;
-    
+
     document.head.appendChild(menuStyle);
     document.body.appendChild(menu);
 
-    // Event listeners
-    menu.querySelector('.close-btn').addEventListener('click', () => {
-      menu.remove();
-      menuStyle.remove();
-    });
+    // spawn particles
+    const particleBox = menu.querySelector('.zepra-particles');
+    for (let i = 0; i < 25; i++) {
+      const s = document.createElement('span');
+      const size = Math.random() * 4 + 2;
+      s.style.width = s.style.height = `${size}px`;
+      s.style.left = `${Math.random() * 100}%`;
+      s.style.top = `${Math.random() * 100}%`;
+      s.style.animationDuration = `${Math.random() * 5 + 5}s`;
+      s.style.animationDelay = `${Math.random() * 5}s`;
+      particleBox.appendChild(s);
+    }
+
+    requestAnimationFrame(() => menu.classList.add('open'));
+
+    const closeMenu = () => {
+      menu.classList.remove('open');
+      setTimeout(() => { menu.remove(); menuStyle.remove(); }, 400);
+    };
+
+    menu.querySelector('.close-btn').addEventListener('click', closeMenu);
 
     menu.addEventListener('click', (e) => {
-      const item = e.target.closest('.menu-item');
-      if (!item) return;
-      
-      const action = item.dataset.action;
+      const link = e.target.closest('a[data-action]');
+      if (!link) return;
+      e.preventDefault();
+      const action = link.dataset.action;
       handleBubbleAction(action);
-      menu.remove();
-      menuStyle.remove();
+      closeMenu();
     });
 
-    // Close on outside click
     setTimeout(() => {
-      document.addEventListener('click', function closeMenu(e) {
+      document.addEventListener('click', function outside(e) {
         if (!menu.contains(e.target) && !STATE.bubble.contains(e.target)) {
-          menu.remove();
-          menuStyle.remove();
-          document.removeEventListener('click', closeMenu);
+          closeMenu();
+          document.removeEventListener('click', outside);
         }
       });
     }, 100);
@@ -732,93 +765,331 @@ function init() {
     const qualified = riskPass && blacklistPass && anonymityPass;
 
     const statusText = qualified ? 'QUALIFIED' : 'NOT QUALIFIED';
-    const statusColor = qualified ? '#39ff14' : '#ff4444';
+    const statusClass = qualified ? 'status-qualified' : 'status-not-qualified';
     let failMsg = '';
     if (!riskPass) failMsg = 'Your risk score is too high. You must change your connection.';
     else if (!blacklistPass) failMsg = 'Your IP is on a blacklist. You must change your connection.';
     else if (!anonymityPass) failMsg = 'Proxy/VPN/Tor detected. Please disable it and try again.';
 
-    const passIcon = '<span style="color:#39ff14;">✔️</span>';
-    const failIcon = '<span style="color:#ff4444;">❌</span>';
-    const clip = chrome.runtime.getURL(qualified ? 'src/media/zepra.webm' : 'src/media/carry.webm');
+    const particles = Array.from({ length: 12 })
+      .map((_, i) => `<span class="particle" style="--i:${i};"></span>`)
+      .join('');
+
+    const shieldSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>`;
+    const eyeSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>`;
+    const globeSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
+    const checkSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="pass"><polyline points="20 6 9 17 4 12"/></svg>`;
+    const xSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="fail"><path d="M18 6 6 18M6 6l12 12"/></svg>`;
+
+    const checks = [
+      { pass: riskPass, label: 'Risk Score Assessment', icon: shieldSVG },
+      { pass: blacklistPass, label: 'Blacklist Verification', icon: eyeSVG },
+      { pass: anonymityPass, label: 'Anonymity Detection', icon: globeSVG },
+    ];
+
+    const checklistHTML = checks
+      .map(
+        (c, i) => `
+        <div class="ipq-check-card" style="--i:${i};">
+          <div class="ipq-check-left">${c.icon}<span>${c.label}</span></div>
+          <div class="ipq-check-result">${c.pass ? checkSVG : xSVG}</div>
+        </div>`
+      )
+      .join('');
+
+    const shieldCheckSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>`;
+    const shieldOffSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 9l6 6M15 9l-6 6"/></svg>`;
+    const headerIcon = qualified ? shieldCheckSVG : shieldOffSVG;
 
     const html = `
       <style>
-        .ipq-wrap{display:flex;flex-direction:column;align-items:center;gap:20px;color:#e2e8f0;max-width:320px;}
-        .ipq-circle{position:relative;width:120px;height:120px;border-radius:50%;overflow:hidden;border:4px solid ${statusColor};box-shadow:0 0 15px ${statusColor};}
-        .ipq-circle video{width:100%;height:100%;object-fit:contain;}
-        .ipq-circle .text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;}
-        .ipq-status{font-size:24px;font-weight:bold;text-shadow:0 0 10px currentColor;}
-        .ipq-score{font-size:32px;font-weight:bold;}
-        .ipq-checklist{list-style:none;padding:0;margin:0;width:100%;}
-        .ipq-checklist li{display:flex;align-items:center;gap:8px;margin:4px 0;}
-        .ipq-message{text-align:center;font-weight:bold;}
-        .ipq-details{width:100%;text-align:left;line-height:1.6;}
-        .ipq-details strong{color:#39ff14;}
+        .styled-modal-content.status-qualified{--ipq-color:#4ade80;}
+        .styled-modal-content.status-not-qualified{--ipq-color:#f43f5e;}
+        .styled-modal-content .styled-modal-header h3{display:flex;align-items:center;gap:6px;}
+        .styled-modal-content .styled-modal-header svg{width:20px;height:20px;}
+        .styled-modal-content.status-qualified .styled-modal-header h3,
+        .styled-modal-content.status-qualified .styled-modal-header svg{color:var(--ipq-color);stroke:var(--ipq-color);filter:drop-shadow(0 0 6px var(--ipq-color));}
+        .styled-modal-content.status-not-qualified .styled-modal-header h3,
+        .styled-modal-content.status-not-qualified .styled-modal-header svg{color:var(--ipq-color);stroke:var(--ipq-color);filter:drop-shadow(0 0 6px var(--ipq-color));}
+
+        :root{--pass-color:#4ade80;--fail-color:#f43f5e;}
+        .ipq-modal{position:relative;overflow:hidden;max-width:360px;}
+        .ipq-grid{position:absolute;inset:0;background-image:linear-gradient(to right,var(--ipq-color)1px,transparent 1px),linear-gradient(var(--ipq-color)1px,transparent 1px);background-size:40px 40px;opacity:0.1;animation:moveGrid 20s linear infinite;pointer-events:none;}
+        @keyframes moveGrid{from{background-position:0 0,0 0;}to{background-position:40px 40px,40px 40px;}}
+        .ipq-main{position:relative;display:flex;flex-direction:column;align-items:center;gap:24px;padding:20px;}
+        .ipq-circle{position:relative;width:180px;height:180px;}
+        .ipq-circle .ring{position:absolute;border-radius:50%;inset:0;}
+        .ipq-circle .ring.outer{border:4px dashed var(--ipq-color);animation:spin 12s linear infinite;}
+        .ipq-circle .ring.inner{inset:20px;border:4px solid var(--ipq-color);opacity:.4;animation:spinReverse 8s linear infinite;}
+        .ipq-circle .ring.glow{box-shadow:0 0 30px var(--ipq-color);}
+        .ipq-circle .radar{position:absolute;inset:0;border-radius:50%;background:conic-gradient(from 0deg,var(--ipq-color)0deg,transparent 60deg);mix-blend-mode:screen;animation:spin 6s linear infinite;opacity:.2;}
+        .ipq-circle .center{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;}
+        .ipq-status{font-size:18px;font-weight:700;color:var(--ipq-color);text-shadow:0 0 8px var(--ipq-color);}
+        .ipq-risk{font-size:40px;font-weight:700;color:var(--ipq-color);}
+        .particle{position:absolute;top:50%;left:50%;width:6px;height:6px;background:var(--ipq-color);border-radius:50%;animation:orbit 6s linear infinite;animation-delay:calc(var(--i)*-0.3s);}
+        @keyframes spin{from{transform:rotate(0);}to{transform:rotate(360deg);}}
+        @keyframes spinReverse{from{transform:rotate(360deg);}to{transform:rotate(0);}}
+        @keyframes orbit{from{transform:rotate(0deg) translateX(90px) rotate(0deg);}to{transform:rotate(360deg) translateX(90px) rotate(-360deg);}}
+
+        .ipq-checklist{width:100%;display:flex;flex-direction:column;gap:12px;}
+        .ipq-check-card{display:flex;align-items:center;justify-content:space-between;padding:12px;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.05);border-radius:8px;transition:background .2s,transform .2s;animation:fadeUp .4s ease forwards;opacity:0;animation-delay:calc(var(--i)*0.1s);}
+        .ipq-check-card:hover{background:rgba(255,255,255,0.1);transform:translateX(4px);}
+        .ipq-check-left{display:flex;align-items:center;gap:8px;}
+        .ipq-check-left svg{width:18px;height:18px;stroke:#9ca3af;}
+        .ipq-check-result svg{width:20px;height:20px;}
+        .ipq-check-result .pass{stroke:var(--pass-color);}
+        .ipq-check-result .fail{stroke:var(--fail-color);}
+        @keyframes fadeUp{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:translateY(0);}}
+
+        .ipq-footer{width:100%;padding:0 20px 20px;}
+        .ipq-summary{font-weight:bold;color:var(--ipq-color);text-align:center;margin-top:8px;}
+        .ipq-info-cards{display:flex;gap:12px;margin-top:12px;}
+        .ipq-info-card{flex:1;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);border-radius:8px;padding:8px;text-align:center;transition:box-shadow .2s;}
+        .ipq-info-card:hover{box-shadow:0 0 15px rgba(255,255,255,0.1);}
+        .ipq-info-label{font-size:12px;color:#9ca3af;}
+        .ipq-info-value{font-size:14px;font-weight:bold;color:#e5e7eb;}
       </style>
-      <div class="ipq-wrap">
-        <div class="ipq-circle">
-          <video autoplay loop muted src="${clip}"></video>
-          <div class="text"><div class="ipq-status" style="color:${statusColor};">${statusText}</div><div class="ipq-score" style="color:${statusColor};">${risk}</div></div>
-        </div>
-        <ul class="ipq-checklist">
-          <li>${riskPass ? passIcon : failIcon} Risk Score (<30)</li>
-          <li>${blacklistPass ? passIcon : failIcon} Blacklist Check (Clean)</li>
-          <li>${anonymityPass ? passIcon : failIcon} Anonymity Check (No Proxy/VPN/Tor)</li>
-        </ul>
-        <div class="ipq-message" style="color:${statusColor};">${qualified ? 'Your IP is clean and ready to use.' : failMsg}</div>
-        <div class="ipq-details" style="margin-top:10px;">
-          <div><strong>IP:</strong> ${ip} - ${flag} ${city ? city+', ' : ''}${cc}</div>
-          <div><strong>ISP:</strong> ${isp || 'Unknown'}</div>
-        </div>
+      <div class="ipq-modal">
+        <div class="ipq-grid"></div>
+        <main class="ipq-main">
+          <div class="ipq-circle">
+            <div class="ring outer"></div>
+            <div class="ring inner"></div>
+            <div class="ring glow"></div>
+            <div class="radar"></div>
+            <div class="center">
+              <div class="ipq-status">${statusText}</div>
+              <div class="ipq-risk">${risk}</div>
+            </div>
+            ${particles}
+          </div>
+          <div class="ipq-checklist">${checklistHTML}</div>
+        </main>
+        <footer class="ipq-footer">
+          <div class="ipq-summary">${qualified ? 'Your IP is clean and ready to use.' : failMsg}</div>
+          <div class="ipq-info-cards">
+            <div class="ipq-info-card"><div class="ipq-info-label">IP</div><div class="ipq-info-value">${ip} - ${flag} ${city ? city+', ' : ''}${cc}</div></div>
+            <div class="ipq-info-card"><div class="ipq-info-label">ISP</div><div class="ipq-info-value">${isp || 'Unknown'}</div></div>
+          </div>
+        </footer>
       </div>`;
-    createStyledModal('IP Qualification', html);
+
+    const modal = createStyledModal(`${headerIcon} IP Qualification`, html);
+    modal.querySelector('.styled-modal-content').classList.add(statusClass);
   }
 
   function showIPModal(info) {
-    const { ip, raw = {}, ...rest } = info || {};
-    const entries = { ...rest, ...raw };
-    delete entries.ip;
-    delete entries.raw;
-    const rows = Object.entries(entries)
-      .map(([k, v]) => `<div><strong style="color: #ffd600;">${k.replace(/_/g, ' ')}:</strong> ${v === undefined ? 'Unknown' : v}</div>`)
-      .join('');
-    const modal = createStyledModal('IP Information', `
-      <div style="background: linear-gradient(120deg, #120f12 80%, #0a0f17 100%); padding: 20px; border-radius: 10px; margin: 10px 0;">
-        <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 15px;">
-          <strong style="color: #39ff14;">IP Address:</strong>
-          <span style="color: #e2e8f0; font-family: monospace;">${ip || 'Unknown'}</span>
-          <button onclick="navigator.clipboard.writeText('${ip || ''}')" style="background: #22c55e; border: none; color: white; padding: 5px 10px; border-radius: 5px; cursor: pointer; font-size: 12px;">Copy</button>
+    const {
+      ip = 'Unknown',
+      country = 'Unknown',
+      city = 'Unknown',
+      postal = 'Unknown',
+      timezone = 'Unknown',
+      isp = 'Unknown'
+    } = info || {};
+
+    const globe = `<svg class="ip-info-header-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
+    const mapPin = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 1 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>`;
+    const mail = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><polyline points="3 7 12 13 21 7"/></svg>`;
+    const clock = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+    const server = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="8" rx="2"/><rect x="2" y="14" width="20" height="8" rx="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>`;
+    const copySVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+    const checkSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+    const modal = createStyledModal(`${globe} IP Information`, `
+      <div class="ip-info-ip-box">
+        <span class="ip-info-address">${ip}</span>
+        <button class="ip-info-copy">${copySVG}<span>Copy</span></button>
+      </div>
+      <div class="ip-info-grid">
+        <div class="ip-info-card">
+          <div class="ip-info-card-icon">${mapPin}</div>
+          <div>
+            <div class="ip-info-card-label">Country</div>
+            <div class="ip-info-card-value">${country}</div>
+          </div>
         </div>
-        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; color: #e2e8f0;">
-          ${rows}
+        <div class="ip-info-card">
+          <div class="ip-info-card-icon">${mapPin}</div>
+          <div>
+            <div class="ip-info-card-label">City</div>
+            <div class="ip-info-card-value">${city}</div>
+          </div>
+        </div>
+        <div class="ip-info-card">
+          <div class="ip-info-card-icon">${mail}</div>
+          <div>
+            <div class="ip-info-card-label">Postal Code</div>
+            <div class="ip-info-card-value">${postal}</div>
+          </div>
+        </div>
+        <div class="ip-info-card">
+          <div class="ip-info-card-icon">${clock}</div>
+          <div>
+            <div class="ip-info-card-label">Timezone</div>
+            <div class="ip-info-card-value">${timezone}</div>
+          </div>
+        </div>
+        <div class="ip-info-card ip-info-card-span">
+          <div class="ip-info-card-icon">${server}</div>
+          <div>
+            <div class="ip-info-card-label">ISP</div>
+            <div class="ip-info-card-value">${isp}</div>
+          </div>
         </div>
       </div>
     `);
+
+    const contentEl = modal.querySelector('.styled-modal-content');
+    const headerEl = modal.querySelector('.styled-modal-header');
+    const bodyEl = modal.querySelector('.styled-modal-body');
+    contentEl.classList.add('ip-info-modal');
+    headerEl.classList.add('ip-info-header');
+    bodyEl.classList.add('ip-info-body');
+
+    const style = document.createElement('style');
+    style.textContent = `
+      #zepra-styled-modal .ip-info-modal{background-color:rgba(17,24,39,0.8);backdrop-filter:blur(16px);border:1px solid rgba(56,189,248,0.2);box-shadow:0 0 30px rgba(56,189,248,0.1);border-radius:1.25rem;}
+      #zepra-styled-modal .ip-info-header{background:linear-gradient(90deg,rgba(56,189,248,0.2),rgba(56,189,248,0));border-bottom:1px solid rgba(56,189,248,0.2);}
+      #zepra-styled-modal .ip-info-header h3{margin:0;color:#fff;font-weight:700;display:flex;align-items:center;gap:0.5rem;}
+      #zepra-styled-modal .ip-info-header-icon{width:24px;height:24px;animation:spin 20s linear infinite;}
+      #zepra-styled-modal .ip-info-body{padding:1.5rem;}
+      #zepra-styled-modal .ip-info-ip-box{background-color:rgba(0,0,0,0.3);border:1px solid rgba(56,189,248,0.2);border-radius:0.75rem;padding:0.75rem 1rem;display:flex;align-items:center;justify-content:space-between;margin-bottom:1.5rem;}
+      #zepra-styled-modal .ip-info-address{font-family:monospace;font-size:1.25rem;color:#4ade80;text-shadow:0 0 8px #4ade80;}
+      #zepra-styled-modal .ip-info-copy{display:flex;align-items:center;gap:0.25rem;background-color:rgba(56,189,248,0.15);border:1px solid rgba(56,189,248,0.4);color:#e2e8f0;padding:0.5rem 0.75rem;border-radius:0.5rem;cursor:pointer;transition:all 0.3s;}
+      #zepra-styled-modal .ip-info-copy:hover{background-color:rgba(56,189,248,0.3);}
+      #zepra-styled-modal .ip-info-copy.copied{background-color:rgba(74,222,128,0.25);border-color:#4ade80;color:#4ade80;}
+      #zepra-styled-modal .ip-info-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1rem;}
+      #zepra-styled-modal .ip-info-card{background-color:rgba(31,41,55,0.5);border:1px solid #374151;border-radius:0.75rem;padding:0.75rem;display:flex;align-items:center;gap:0.5rem;}
+      #zepra-styled-modal .ip-info-card-icon{width:32px;height:32px;display:flex;align-items:center;justify-content:center;background-color:rgba(56,189,248,0.15);border-radius:9999px;flex-shrink:0;}
+      #zepra-styled-modal .ip-info-card-icon svg{width:18px;height:18px;}
+      #zepra-styled-modal .ip-info-card-label{font-size:0.75rem;color:#d1d5db;}
+      #zepra-styled-modal .ip-info-card-value{font-weight:600;color:#fff;}
+      #zepra-styled-modal .ip-info-card-span{grid-column:span 2;}
+      @keyframes spin{from{transform:rotate(0);}to{transform:rotate(360deg);}}
+    `;
+    modal.appendChild(style);
+
+    const copyBtn = modal.querySelector('.ip-info-copy');
+    copyBtn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(ip);
+        copyBtn.classList.add('copied');
+        copyBtn.innerHTML = `${checkSVG}<span>Copied!</span>`;
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          copyBtn.innerHTML = `${copySVG}<span>Copy</span>`;
+        }, 1500);
+      } catch (e) {}
+    });
   }
 
   async function showFakeInfoModal() {
     const COUNTRY_CODES = "AF AX AL DZ AS AD AO AI AQ AR AM AW AU AT AZ BS BH BD BB BY BE BZ BJ BM BT BO BQ BA BW BV BR IO BN BG BF BI KH CM CA CV KY CF TD CL CN CX CC CO KM CG CD CK CR CI HR CU CW CY CZ DK DJ DM DO EC EG SV GQ ER EE ET FK FO FJ FI FR GF PF TF GA GM GE DE GH GI GR GL GD GP GU GT GG GN GW GY HT HM VA HN HK HU IS IN ID IR IQ IE IM IL IT JM JP JE JO KZ KE KI KP KR KW KG LA LV LB LS LR LY LI LT LU MO MK MG MW MY MV ML MT MH MQ MR MU YT MX FM MD MC MN ME MS MA MZ MM NA NR NP NL NC NZ NI NE NG NU NF MP NO OM PK PW PS PA PG PY PE PH PN PL PT PR QA RE RO RU RW BL SH KN LC MF PM VC WS SM ST SA SN RS SC SL SG SX SK SI SB SO ZA GS SS ES LK SD SR SJ SE CH SY TW TJ TZ TH TL TG TK TO TT TN TR TM TC TV UG UA AE GB US UM UY UZ VU VE VN VG VI WF EH YE ZM ZW".split(' ');
     const datalist = `<datalist id="fiNatList">${COUNTRY_CODES.map(c=>`<option value="${c}">`).join('')}</datalist>`;
     const { fakeInfo } = await chrome.storage.local.get('fakeInfo');
-    const content = fakeInfo ? `
-      <div id="fiResult"></div>
-    ` : `
-      <div style="margin-bottom:15px; display:flex; gap:10px; flex-wrap:wrap;">
-        <select id="fiGender" style="flex:1; padding:6px; border-radius:6px; background:#0b1220; color:#e2e8f0; border:1px solid #334155;">
+
+    const icons = {
+      userPlus: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" x2="19" y1="8" y2="14"/><line x1="22" x2="16" y1="11" y2="11"/></svg>`,
+      mail: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"/><rect x="2" y="4" width="20" height="16" rx="2"/></svg>`,
+      phone: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"/></svg>`,
+      house: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>`,
+      cake: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-8a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8"/><path d="M4 16s.5-1 2-1 2.5 2 4 2 2.5-2 4-2 2.5 2 4 2 2-1 2-1"/><path d="M2 21h20"/><path d="M7 8v3"/><path d="M12 8v3"/><path d="M17 8v3"/><path d="M7 4h.01"/><path d="M12 4h.01"/><path d="M17 4h.01"/></svg>`,
+      copy: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`,
+      pencil: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>`,
+      plus: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg>`
+    };
+
+    const content = `
+      <div class="fi-controls">
+        <select id="fiGender">
           <option value="">Any Gender</option>
           <option value="male">Male</option>
           <option value="female">Female</option>
         </select>
-        <input id="fiNat" list="fiNatList" placeholder="Country code" style="flex:1; padding:6px; border-radius:6px; background:#0b1220; color:#e2e8f0; border:1px solid #334155;" />
-        <button id="fiGenerate" style="background:linear-gradient(45deg,#4ecdc4,#44a08d); border:none; color:#fff; padding:6px 12px; border-radius:6px; cursor:pointer;">Generate</button>
+        <input id="fiNat" list="fiNatList" placeholder="Country code (e.g., us)" />
       </div>
       ${datalist}
-      <div id="fiResult" style="display:none;"></div>
+      <main id="fiMain" class="fi-main">
+        <div id="fiLoader" class="fi-loader"></div>
+        <div id="fiData" class="fi-data"></div>
+      </main>
+      <footer class="fi-footer">
+        <button id="fiRegenerate" class="fi-regenerate"><span class="fi-regenerate-text">Regenerate Info</span></button>
+      </footer>
     `;
-    const modal = createStyledModal('Fake User Info', content);
+    const modal = createStyledModal(`${icons.userPlus} Fake User Info`, content);
+
+    const contentEl = modal.querySelector('.styled-modal-content');
+    const headerEl = modal.querySelector('.styled-modal-header');
+    const bodyEl = modal.querySelector('.styled-modal-body');
+    contentEl.classList.add('fi-modal');
+    headerEl.classList.add('fi-header');
+    bodyEl.classList.add('fi-body');
+
+    const style = document.createElement('style');
+    style.textContent = `
+      #zepra-styled-modal .fi-modal{background-color:rgba(17,24,39,0.7);backdrop-filter:blur(24px);border:1px solid rgba(74,222,128,0.2);box-shadow:0 0 40px rgba(10,70,30,0.5);border-radius:1.25rem;max-width:360px;width:90%;}
+      #zepra-styled-modal .fi-header{background:rgba(0,0,0,0.2);border-bottom:1px solid rgba(74,222,128,0.2);}
+      #zepra-styled-modal .fi-header h3{margin:0;display:flex;align-items:center;gap:0.5rem;color:#fff;font-weight:700;}
+      #zepra-styled-modal .fi-header svg{width:20px;height:20px;color:#4ade80;stroke:#4ade80;filter:drop-shadow(0 0 6px #4ade80);}
+      #zepra-styled-modal .fi-body{padding:1rem;display:flex;flex-direction:column;gap:1rem;}
+      #zepra-styled-modal .fi-controls{display:flex;gap:0.5rem;}
+      #zepra-styled-modal .fi-controls select,#zepra-styled-modal .fi-controls input{flex:1;background:rgba(0,0,0,0.3);border:1px solid #334155;border-radius:0.5rem;color:#e2e8f0;padding:0.5rem;font-size:0.875rem;}
+      #zepra-styled-modal .fi-main{display:flex;flex-direction:column;gap:1rem;}
+      #zepra-styled-modal .fi-loader .fi-skel-card{height:80px;border-radius:0.75rem;background:#374151;animation:fiPulse 1.5s ease-in-out infinite;}
+      #zepra-styled-modal .fi-loader .fi-skel-line{height:16px;border-radius:0.25rem;background:#374151;animation:fiPulse 1.5s ease-in-out infinite;margin-top:0.5rem;}
+      @keyframes fiPulse{0%,100%{opacity:1;}50%{opacity:0.4;}}
+      #zepra-styled-modal .fi-data{display:flex;flex-direction:column;gap:1rem;}
+      #zepra-styled-modal .fi-id-card{position:relative;display:flex;align-items:center;gap:0.75rem;background:rgba(31,41,55,0.5);border:1px solid #374151;border-radius:0.75rem;padding:0.75rem;}
+      #zepra-styled-modal .fi-avatar{width:64px;height:64px;border-radius:50%;object-fit:cover;border:2px solid rgba(74,222,128,0.6);box-shadow:0 0 10px rgba(74,222,128,0.4);}
+      #zepra-styled-modal .fi-pic-add{position:absolute;top:-8px;right:-8px;}
+      #zepra-styled-modal .fi-name{font-weight:600;color:#fff;}
+      #zepra-styled-modal .fi-age{font-size:0.875rem;color:#d1d5db;display:flex;align-items:center;gap:0.25rem;}
+      #zepra-styled-modal .fi-age svg{width:16px;height:16px;}
+      #zepra-styled-modal .fi-info-row{display:flex;align-items:center;justify-content:space-between;background:rgba(31,41,55,0.5);border:1px solid #374151;border-radius:0.75rem;padding:0.5rem 0.75rem;}
+      #zepra-styled-modal .fi-info-left{display:flex;align-items:center;gap:0.5rem;}
+      #zepra-styled-modal .fi-info-icon{width:32px;height:32px;background:rgba(74,222,128,0.15);border-radius:9999px;display:flex;align-items:center;justify-content:center;}
+      #zepra-styled-modal .fi-info-icon svg{width:18px;height:18px;color:#4ade80;stroke:#4ade80;}
+      #zepra-styled-modal .fi-info-label{font-size:0.75rem;color:#d1d5db;}
+      #zepra-styled-modal .fi-info-value{font-weight:600;color:#fff;font-size:0.875rem;}
+      #zepra-styled-modal .fi-actions{display:flex;gap:0.25rem;}
+      #zepra-styled-modal .fi-action{position:relative;background:transparent;border:none;color:#e2e8f0;width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:background 0.2s;}
+      #zepra-styled-modal .fi-action:hover{background:rgba(74,222,128,0.15);}
+      #zepra-styled-modal .fi-action svg{width:14px;height:14px;}
+      #zepra-styled-modal .fi-action::after{content:attr(data-tip);position:absolute;bottom:100%;left:50%;transform:translate(-50%,-4px);background:#000;color:#fff;padding:2px 6px;border-radius:4px;font-size:10px;white-space:nowrap;opacity:0;pointer-events:none;transition:opacity 0.2s;}
+      #zepra-styled-modal .fi-action:hover::after{opacity:1;}
+      #zepra-styled-modal .fi-footer{padding-top:0.5rem;border-top:1px solid rgba(74,222,128,0.2);}
+      #zepra-styled-modal .fi-regenerate{width:100%;background:#4ade80;color:#0b1b13;font-weight:600;border:none;border-radius:0.75rem;padding:0.75rem;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:0.5rem;transition:opacity 0.3s;}
+      #zepra-styled-modal .fi-regenerate:disabled{opacity:0.5;cursor:not-allowed;}
+      #zepra-styled-modal .fi-spinner{width:16px;height:16px;border:2px solid rgba(0,0,0,0.2);border-top-color:#0b1b13;border-radius:50%;animation:spin 1s linear infinite;}
+      @keyframes spin{to{transform:rotate(360deg);}}
+    `;
+    document.head.appendChild(style);
+
+    const loader = modal.querySelector('#fiLoader');
+    const dataEl = modal.querySelector('#fiData');
+    const regenBtn = modal.querySelector('#fiRegenerate');
+
+    function showLoader(){
+      loader.innerHTML = `
+        <div class="fi-skel-card"></div>
+        <div class="fi-skel-line"></div>
+        <div class="fi-skel-line"></div>
+        <div class="fi-skel-line"></div>
+      `;
+      loader.style.display = 'block';
+      dataEl.style.display = 'none';
+    }
+
+    function hideLoader(){
+      loader.style.display = 'none';
+    }
 
     async function generate(){
+      showLoader();
+      regenBtn.disabled = true;
+      regenBtn.innerHTML = '<span class="fi-spinner"></span><span>Generating...</span>';
       try {
         const gender = modal.querySelector('#fiGender').value;
         const nat = modal.querySelector('#fiNat').value.trim();
@@ -827,57 +1098,67 @@ function init() {
         await chrome.storage.local.set({ fakeInfo: resp.data });
         render(resp.data);
       } catch(e){
+        hideLoader();
+        regenBtn.disabled = false;
+        regenBtn.innerHTML = '<span class="fi-regenerate-text">Regenerate Info</span>';
         showNotification('Failed to generate: '+e.message);
       }
     }
 
     function render(user){
-      const fi = modal.querySelector('#fiResult');
       const name = `${user.name?.first || ''} ${user.name?.last || ''}`.trim();
       const address = `${user.location?.street?.number || ''} ${user.location?.street?.name || ''}, ${user.location?.city || ''}, ${user.location?.country || ''}`.trim();
       const age = user.dob?.age || '';
       const fields = [
-        { label:'Name', value:name, key:'fullName' },
-        { label:'Email', value:user.email, key:'email' },
-        { label:'Phone', value:user.phone, key:'phone' },
-        { label:'Address', value:address, key:'address1' },
-        { label:'Age', value:age, key:'age' }
+        { label:'Email', value:user.email, key:'email', icon:icons.mail },
+        { label:'Phone', value:user.phone, key:'phone', icon:icons.phone },
+        { label:'Address', value:address, key:'address1', icon:icons.house }
       ];
-      fi.innerHTML = `
-        <div style="text-align:center; margin-bottom:15px; position:relative; display:inline-block;">
-          ${user.picture?.large ? `<img src="${user.picture.large}" style="width:80px;height:80px;border-radius:50%;object-fit:cover;"/>` : ''}
-          ${user.picture?.large ? `<button id="fiPicAdd" title="Add Picture to Identity" style="position:absolute;top:-6px;right:-6px;width:24px;height:24px;border-radius:50%;border:none;background:#3b82f6;color:#fff;cursor:pointer;font-size:16px;">+</button>` : ''}
+      dataEl.innerHTML = `
+        <div class="fi-id-card">
+          ${user.picture?.large ? `<img class="fi-avatar" src="${user.picture.large}"/>` : ''}
+          <div class="fi-id-info">
+            <div class="fi-name">${name || 'Unknown'}</div>
+            <div class="fi-age">${icons.cake} ${age ? `${age} years old` : ''}</div>
+          </div>
+          ${user.picture?.large ? `<button id="fiPicAdd" class="fi-action fi-pic-add" data-tip="Add Picture">${icons.plus}</button>` : ''}
         </div>
         ${fields.map((f,i)=>`
-          <div style="display:flex; align-items:center; gap:8px; margin-bottom:8px;">
-            <strong style="color:#ffd600; min-width:70px;">${f.label}:</strong>
-            <span style="flex:1; color:#e2e8f0;">${f.value || 'Unknown'}</span>
-            <button data-copy="${i}" style="background:#22c55e;border:none;color:#fff;padding:4px 8px;border-radius:5px;cursor:pointer;font-size:12px;">Copy</button>
-            <button data-write="${i}" style="background:#ff6b6b;border:none;color:#fff;padding:4px 8px;border-radius:5px;cursor:pointer;font-size:12px;">Write Here</button>
-            <button data-add="${i}" title="Add to Identity" style="background:#3b82f6;border:none;color:#fff;padding:4px 8px;border-radius:5px;cursor:pointer;font-size:12px;">ATI</button>
+          <div class="fi-info-row">
+            <div class="fi-info-left">
+              <div class="fi-info-icon">${f.icon}</div>
+              <div>
+                <div class="fi-info-label">${f.label}</div>
+                <div class="fi-info-value">${f.value || 'Unknown'}</div>
+              </div>
+            </div>
+            <div class="fi-actions">
+              <button class="fi-action" data-copy="${i}" data-tip="Copy">${icons.copy}</button>
+              <button class="fi-action" data-write="${i}" data-tip="Write Here">${icons.pencil}</button>
+              <button class="fi-action" data-add="${i}" data-tip="Add to Identity">${icons.plus}</button>
+            </div>
           </div>
         `).join('')}
-        <div style="text-align:center; margin-top:10px;">
-          <button id="fiRegenerate" style="background:linear-gradient(45deg,#feca57,#ff9ff3); border:none; color:#fff; padding:8px 16px; border-radius:20px; cursor:pointer; font-weight:bold;">Regenerate Info</button>
-        </div>
       `;
-      fi.style.display = 'block';
+      hideLoader();
+      dataEl.style.display = 'flex';
+      regenBtn.disabled = false;
+      regenBtn.innerHTML = '<span class="fi-regenerate-text">Regenerate Info</span>';
 
-      const picBtn = fi.querySelector('#fiPicAdd');
+      const picBtn = dataEl.querySelector('#fiPicAdd');
       if(picBtn){
         picBtn.addEventListener('click',()=>{
           addFieldToIdentity(picBtn, user.picture.large, 'profilePictureUrl', 'Picture Saved!');
         });
       }
-
-      fi.querySelectorAll('[data-copy]').forEach(btn=>{
+      dataEl.querySelectorAll('[data-copy]').forEach(btn=>{
         btn.addEventListener('click',()=>{
           const idx = btn.getAttribute('data-copy');
           navigator.clipboard.writeText(fields[idx].value || '');
           showNotification('Copied to clipboard');
         });
       });
-      fi.querySelectorAll('[data-write]').forEach(btn=>{
+      dataEl.querySelectorAll('[data-write]').forEach(btn=>{
         btn.addEventListener('click',()=>{
           const idx = btn.getAttribute('data-write');
           const text = fields[idx].value || '';
@@ -886,26 +1167,23 @@ function init() {
           typeAnswer(text);
         });
       });
-      fi.querySelectorAll('[data-add]').forEach(btn=>{
+      dataEl.querySelectorAll('[data-add]').forEach(btn=>{
         btn.addEventListener('click',()=>{
           const idx = btn.getAttribute('data-add');
           addFieldToIdentity(btn, fields[idx].value, fields[idx].key);
         });
       });
-      fi.querySelector('#fiRegenerate')?.addEventListener('click', async ()=>{
-        await chrome.storage.local.remove('fakeInfo');
-        modal.remove();
-        showFakeInfoModal();
-      });
     }
+
+    regenBtn.addEventListener('click', async ()=>{
+      await chrome.storage.local.remove('fakeInfo');
+      generate();
+    });
 
     if(fakeInfo){
       render(fakeInfo);
-    } else {
-      modal.querySelector('#fiGenerate')?.addEventListener('click', generate);
     }
   }
-
   async function showRealAddressModal(){
     const saved = (await chrome.storage.local.get('realAddress')).realAddress;
     const content = `
@@ -1390,13 +1668,13 @@ function init() {
     const modal = document.createElement('div');
     modal.id = 'zepra-modal';
     modal.innerHTML = `
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3 class="zepra-gradient">Zepra Answer</h3>
-          <button class="modal-close">&times;</button>
-        </div>
-        <div class="modal-body">
-          <div class="question-text">${selectedText}</div>
+      <div class="za-modal">
+        <header class="za-header">
+          <h2>Zepra Answer</h2>
+          <button class="modal-close">×</button>
+        </header>
+        <main class="za-body">
+          <div class="za-question-box">${selectedText}</div>
           <div class="answer-container${showReasoning ? ' split' : ''}">
             <div class="loading"></div>
             ${showReasoning ? `
@@ -1413,17 +1691,57 @@ function init() {
               </div>
             </div>
             ` : `
-            <div class="answer-text" style="display: none;"></div>
+            <div class="answer-text" style="display:none;"></div>
             `}
           </div>
-          <div class="modal-actions" style="display: none;">
-            <button class="btn-write-here">Write Here</button>
-            <button class="btn-write-all">Write All</button>
-            ${showReasoning ? '' : '<button class="btn-copy">Copy</button>'}
-            <button class="btn-humanizer">AI Humanizer</button>
-            <button class="btn-use-prompt">Use Custom Prompt</button>
+        </main>
+        <footer class="za-footer">
+          <div class="modal-actions" style="display:none;">
+            <button class="btn-write-here action-btn" data-color="cyan">
+              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12.67 19a2 2 0 0 0 1.416-.588l6.154-6.172a6 6 0 0 0-8.49-8.49L5.586 9.914A2 2 0 0 0 5 11.328V18a1 1 0 0 0 1 1z" />
+                <path d="M16 8 2 22" />
+                <path d="M17.5 15H9" />
+              </svg>
+              <span>Write Here</span>
+            </button>
+            <button class="btn-write-all action-btn" data-color="gray">
+              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12.67 19a2 2 0 0 0 1.416-.588l6.154-6.172a6 6 0 0 0-8.49-8.49L5.586 9.914A2 2 0 0 0 5 11.328V18a1 1 0 0 0 1 1z" />
+                <path d="M16 8 2 22" />
+                <path d="M17.5 15H9" />
+              </svg>
+              <span>Write All</span>
+            </button>
+            ${showReasoning ? '' : `<button class="btn-copy action-btn" data-color="pink">
+              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+              </svg>
+              <span>Copy</span>
+            </button>`}
+            <button class="btn-humanizer action-btn" data-color="teal">
+              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M15 4V2" />
+                <path d="M15 16v-2" />
+                <path d="M8 9h2" />
+                <path d="M20 9h2" />
+                <path d="M17.8 11.8 19 13" />
+                <path d="M15 9h.01" />
+                <path d="M17.8 6.2 19 5" />
+                <path d="m3 21 9-9" />
+                <path d="M12.2 6.2 11 5" />
+              </svg>
+              <span>AI Humanizer</span>
+            </button>
+            <button class="btn-use-prompt action-btn" data-color="yellow">
+              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z" />
+              </svg>
+              <span>Use Custom Prompt</span>
+            </button>
           </div>
-        </div>
+        </footer>
       </div>
     `;
 
@@ -1433,7 +1751,8 @@ function init() {
       left: 0;
       width: 100%;
       height: 100%;
-      background: rgba(0, 0, 0, 0.7);
+      background-color: rgba(0, 0, 0, 0.7);
+      backdrop-filter: blur(4px);
       z-index: 2147483647;
       display: flex;
       align-items: center;
@@ -1448,146 +1767,162 @@ function init() {
         to { opacity: 1; }
       }
 
-      @keyframes rainbowBorder {
-        0% { border-color: #ff6b6b; box-shadow: 0 0 20px #ff6b6b; }
-        16% { border-color: #4ecdc4; box-shadow: 0 0 20px #4ecdc4; }
-        32% { border-color: #45b7d1; box-shadow: 0 0 20px #45b7d1; }
-        48% { border-color: #96ceb4; box-shadow: 0 0 20px #96ceb4; }
-        64% { border-color: #feca57; box-shadow: 0 0 20px #feca57; }
-        80% { border-color: #ff9ff3; box-shadow: 0 0 20px #ff9ff3; }
-        100% { border-color: #ff6b6b; box-shadow: 0 0 20px #ff6b6b; }
-      }
-
       .answer-container.split .split-pane{display:flex;gap:10px;}
       .answer-container.split .pane{flex:1;background:#1f1f1f;padding:10px;border-radius:6px;display:flex;flex-direction:column;}
       .answer-container.split .pane-title{font-weight:bold;margin-bottom:6px;}
       .answer-container.split .pane button{align-self:flex-end;margin-top:8px;}
-      .thinking-icon{display:inline-block;margin-right:6px;animation:pulse 1s infinite;}
-      @keyframes pulse{0%,100%{filter:drop-shadow(0 0 0 #39ff14);}50%{filter:drop-shadow(0 0 6px #39ff14);}}
 
-      .modal-content {
-        background: linear-gradient(135deg, #23272b 0%, #120f12 100%);
-        border-radius: 15px;
-        padding: 0;
-        max-width: 500px;
+      .za-modal {
+        background-color: rgba(17,24,39,0.8);
+        backdrop-filter: blur(16px);
+        border: 1px solid rgba(244,63,94,0.2);
+        box-shadow: 0 0 30px rgba(244,63,94,0.1);
+        border-radius: 1rem;
         width: 90%;
-        max-height: 80vh;
-        overflow: hidden;
-        border: 3px solid #ff6b6b;
-        animation: rainbowBorder 3s linear infinite;
-        box-shadow: 0 10px 30px rgba(0,0,0,0.3);
-      }
-      
-      .modal-header {
-        background: rgba(0,0,0,0.2);
-        padding: 15px 20px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        border-bottom: 1px solid #292d33;
-      }
-      
-      .modal-header h3 {
-        margin: 0;
-        color: #39ff14;
-        font-size: 18px;
-        font-weight: bold;
-      }
-      
-      .modal-close {
-        background: none;
-        border: none;
-        color: #e2e8f0;
-        font-size: 24px;
-        cursor: pointer;
-        padding: 0;
-        width: 30px;
-        height: 30px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: background 0.2s;
-      }
-      
-      .modal-close:hover {
-        background: rgba(255,255,255,0.2);
-      }
-      
-      .modal-body {
-        padding: 20px;
-        color: #e2e8f0;
-        max-height: 70vh;
-        overflow-y: auto;
+        max-width: 600px;
+        max-height: 85vh;
+        display:flex;
+        flex-direction:column;
+        overflow:hidden;
       }
 
-      .question-text {
-        background: rgba(0,0,0,0.2);
-        padding: 15px;
-        border-radius: 10px;
-        margin-bottom: 20px;
-        font-style: italic;
-        border-left: 4px solid #feca57;
-        max-height: 200px;
-        overflow-y: auto;
+      .za-header,
+      .za-footer {
+        padding: 1rem 1.25rem;
+        display:flex;
+        align-items:center;
+        justify-content:space-between;
+        border-bottom:1px solid rgba(244,63,94,0.2);
+      }
+
+      .za-footer {
+        border-bottom:none;
+        border-top:1px solid rgba(244,63,94,0.2);
+      }
+
+      .za-header h2 {
+        color: #4ade80;
+        margin:0;
+        font-size:1.25rem;
+        text-shadow:0 0 8px #4ade80;
+      }
+
+      .modal-close {
+        background:none;
+        border:none;
+        color:#e2e8f0;
+        font-size:1.25rem;
+        width:2rem;
+        height:2rem;
+        border-radius:9999px;
+        cursor:pointer;
+        transition:background .2s;
+      }
+
+      .modal-close:hover {
+        background:rgba(255,255,255,0.1);
+      }
+
+      .za-body {
+        padding:1.25rem;
+        color:#e2e8f0;
+        overflow-y:auto;
+      }
+
+      .za-question-box {
+        background:rgba(17,24,39,0.5);
+        border-left:2px solid #facc15;
+        box-shadow:-2px 0 8px #facc15;
+        padding:1rem;
+        border-radius:0.5rem;
+        margin-bottom:1rem;
+        max-height:200px;
+        overflow-y:auto;
       }
 
       .answer-container {
-        background: rgba(255,255,255,0.1);
-        padding: 15px;
-        border-radius: 10px;
-        margin-bottom: 20px;
-        min-height: 60px;
-        max-height: 300px;
-        overflow-y: auto;
-      }
-      
-      .loading {
-        text-align: center;
-        opacity: 0.7;
-        animation: pulse 1.5s ease-in-out infinite;
-      }
-      
-      @keyframes pulse {
-        0%, 100% { opacity: 0.7; }
-        50% { opacity: 1; }
-      }
-      
-      .answer-text {
-        line-height: 1.6;
-        white-space: pre-wrap;
-      }
-      
-      .modal-actions {
-        display: flex;
-        gap: 10px;
-        justify-content: center;
-      }
-      
-      .modal-actions button {
-        background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
-        border: none;
-        color: white;
-        padding: 10px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: bold;
-        transition: transform 0.2s, box-shadow 0.2s;
-      }
-      
-      .modal-actions button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-      }
-      
-      .btn-write-here {
-        background: linear-gradient(45deg, #4ecdc4, #44a08d) !important;
+        display:flex;
+        flex-direction:column;
+        gap:0.75rem;
+        min-height:60px;
       }
 
-      .btn-use-prompt {
-        background: linear-gradient(45deg, #ffd600, #39ff14) !important;
-        color: #181c20 !important;
+      .answer-text {
+        display:none;
+        flex-direction:column;
+        gap:0.75rem;
       }
+
+      .answer-card {
+        background-color:rgba(31,41,55,0.6);
+        border:1px solid #374151;
+        padding:1rem;
+        border-radius:0.5rem;
+      }
+
+      .loading {
+        text-align:center;
+        padding:1rem;
+        animation:pulse 1.5s ease-in-out infinite;
+      }
+
+      @keyframes pulse {
+        0%,100%{opacity:0.6;}
+        50%{opacity:1;}
+      }
+
+      .modal-actions {
+        display:flex;
+        gap:0.75rem;
+        width:100%;
+      }
+
+      .action-btn {
+        flex:1;
+        display:flex;
+        flex-direction:column;
+        align-items:center;
+        justify-content:center;
+        gap:0.25rem;
+        padding:0.75rem;
+        border:none;
+        border-radius:0.5rem;
+        color:#f8fafc;
+        cursor:pointer;
+        position:relative;
+        overflow:hidden;
+        transition:transform .2s;
+      }
+
+      .action-btn .icon {
+        width:24px;
+        height:24px;
+      }
+
+      .action-btn::before {
+        content:'';
+        position:absolute;
+        inset:0;
+        border-radius:0.5rem;
+        opacity:0;
+        transition:opacity .2s;
+        background:radial-gradient(circle at center, rgba(255,255,255,0.4), transparent 70%);
+        filter:blur(12px);
+      }
+
+      .action-btn:hover::before {
+        opacity:1;
+      }
+
+      .action-btn:hover {
+        transform:translateY(-2px);
+      }
+
+      .action-btn[data-color="cyan"] { background:#06b6d4; }
+      .action-btn[data-color="gray"] { background:#4b5563; }
+      .action-btn[data-color="pink"] { background:#f472b6; }
+      .action-btn[data-color="teal"] { background:#14b8a6; }
+      .action-btn[data-color="yellow"] { background:#facc15; color:#1f2937; }
     `;
 
     document.head.appendChild(style);
@@ -1660,8 +1995,8 @@ function init() {
           });
         } else {
           const ansEl = modal.querySelector('.answer-text');
-          ansEl.style.display = 'block';
-          ansEl.textContent = answer;
+          ansEl.style.display = 'flex';
+          ansEl.innerHTML = answer.split('\n').map(a => `<div class="answer-card">${a}</div>`).join('');
           modal.querySelector('.modal-actions').style.display = 'flex';
           modal.querySelector('.btn-copy').addEventListener('click', () => {
             navigator.clipboard.writeText(answer);

--- a/RESUELV2/custom_web.html
+++ b/RESUELV2/custom_web.html
@@ -1,70 +1,233 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>Custom Sites</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css" />
   <style>
+    /* Root layout */
     body {
-      margin:0;
-      display:flex;
-      flex-direction:column;
-      height:100vh;
-      background:#000;
-      position:relative;
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background: #000;
+      position: relative;
     }
 
-    body::before {
-      content:"";
-      position:fixed;
-      top:0; left:0; right:0; bottom:0;
-      pointer-events:none;
-      padding:3px;
-      border-radius:8px;
-      background:linear-gradient(270deg,#39ff14,#ffe600,#39ff14);
-      background-size:600% 600%;
-      -webkit-mask:
-        linear-gradient(#000 0 0) content-box,
-        linear-gradient(#000 0 0);
-      -webkit-mask-composite:xor;
-              mask-composite:exclude;
-      animation:borderGlow 6s linear infinite;
+    #custom-site-root {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      overflow: hidden;
     }
 
-    @keyframes borderGlow {
-      0% { background-position:0% 50%; }
-      50% { background-position:100% 50%; }
-      100% { background-position:0% 50%; }
+    /* Floating particles */
+    .particles {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 0;
     }
 
-    #controls {
-      display:flex;
-      align-items:center;
-      gap:8px;
-      background:#0b0b0b;
-      padding:8px;
+    .particles span {
+      position: absolute;
+      width: 4px;
+      height: 4px;
+      background: rgba(74, 222, 128, 0.3);
+      border-radius: 50%;
+      animation: float 8s ease-in-out infinite;
     }
 
-    #siteSelect { flex:1; background:#000; color:#e2e8f0; border:1px solid #39ff14; }
+    @keyframes float {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-10px); }
+    }
 
-    #container { flex:1; position:relative; }
+    /* Frame container */
+    .cs-frame {
+      position: relative;
+      z-index: 1;
+      width: 90%;
+      height: 90%;
+      display: flex;
+      flex-direction: column;
+      background-color: rgba(17, 24, 39, 0.5);
+      backdrop-filter: blur(24px);
+      border: 1px solid rgba(74, 222, 128, 0.2);
+      box-shadow: 0 0 40px rgba(10, 70, 30, 0.5);
+      border-radius: 1.25rem;
+      overflow: hidden;
+    }
 
-    #container iframe {
-      position:absolute;
-      top:0; left:0;
-      width:100%; height:100%;
-      border:none;
+    /* Header */
+    .cs-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 1rem;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-bottom: 1px solid rgba(74, 222, 128, 0.2);
+    }
+
+    .cs-header-left {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #4ade80;
+    }
+
+    .cs-header-left svg {
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+
+    .cs-header-left h2 {
+      font-size: 1rem;
+      margin: 0;
+    }
+
+    /* Site selector */
+    .cs-header-center {
+      position: relative;
+    }
+
+    #siteSelect {
+      appearance: none;
+      background-color: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(74, 222, 128, 0.3);
+      color: #e2e8f0;
+      padding: 0.25rem 2rem 0.25rem 0.5rem;
+      border-radius: 0.5rem;
+      min-width: 12rem;
+      cursor: pointer;
+    }
+
+    /* Action buttons */
+    .cs-header-right {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .icon-btn {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      border-radius: 50%;
+      background: transparent;
+      color: #4ade80;
+      cursor: pointer;
+      transition: background 0.2s ease;
+      font-size: 0; /* hide any text content */
+    }
+
+    .icon-btn:hover {
+      background-color: rgba(74, 222, 128, 0.1);
+    }
+
+    .icon-btn svg {
+      width: 18px;
+      height: 18px;
+      pointer-events: none;
+    }
+
+    /* Tooltip */
+    .icon-btn::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: 120%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #000;
+      color: #fff;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s;
+    }
+
+    .icon-btn:hover::after {
+      opacity: 1;
+    }
+
+    #toggleSelect::before {
+      content: "";
+      display: block;
+      width: 18px;
+      height: 18px;
+      background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="%234ade80"><path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>') center/contain no-repeat;
+    }
+
+    /* Content area */
+    .cs-content {
+      flex-grow: 1;
+      margin: 0.5rem;
+      border: 2px dashed rgba(74, 222, 128, 0.2);
+      border-radius: 1rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .cs-content iframe {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      border: none;
     }
   </style>
 </head>
 <body>
-  <div id="controls">
-    <select id="siteSelect"></select>
-    <button id="writeHereBtn" class="btn">Write Here</button>
-    <button id="clearDataBtn" class="btn warn">Remove Cookies</button>
-    <button id="toggleSelect" class="btn">Hide</button>
+  <div id="custom-site-root">
+    <div class="particles"></div>
+    <div class="cs-frame">
+      <header class="cs-header">
+        <div class="cs-header-left">
+          <!-- Globe icon -->
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          <h2>Custom Site</h2>
+        </div>
+        <div class="cs-header-center">
+          <select id="siteSelect"></select>
+        </div>
+        <div class="cs-header-right">
+          <button id="writeHereBtn" class="icon-btn" data-tooltip="Write Here" aria-label="Write Here">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+          </button>
+          <button id="clearDataBtn" class="icon-btn" data-tooltip="Remove Cookies" aria-label="Remove Cookies">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+          </button>
+          <button id="toggleSelect" class="icon-btn" data-tooltip="Toggle Select" aria-label="Toggle Select"></button>
+        </div>
+      </header>
+      <main class="cs-content" id="container"></main>
+    </div>
   </div>
-  <div id="container"></div>
+
+  <script>
+    const particleContainer = document.querySelector('.particles');
+    for (let i = 0; i < 20; i++) {
+      const span = document.createElement('span');
+      span.style.left = Math.random() * 100 + '%';
+      span.style.top = Math.random() * 100 + '%';
+      span.style.animationDelay = (Math.random() * 5) + 's';
+      particleContainer.appendChild(span);
+    }
+  </script>
   <script src="custom_web.js"></script>
 </body>
 </html>
+

--- a/RESUELV2/identities.html
+++ b/RESUELV2/identities.html
@@ -1,95 +1,230 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>Identities</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css" />
   <script src="theme.js"></script>
   <style>
-    body{background:#000;color:#e2e8f0;font-family:Arial,sans-serif;margin:0;padding:20px;overflow:hidden;}
-    #bgVideo{position:fixed;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:-1;opacity:0.3;}
-    h1{margin-top:0;}
-    .grid{display:flex;flex-wrap:wrap;gap:16px;margin-top:20px;}
-    .card{background:var(--card);border:2px solid #292d33;border-radius:12px;padding:12px;width:220px;position:relative;box-shadow:0 0 12px rgba(57,255,20,0.2);text-align:center;}
-    .card.active{border-color:#39ff14;box-shadow:0 0 20px #39ff14;}
-    .pic-wrap{margin:0 auto 8px;width:80px;height:80px;border-radius:50%;padding:3px;background:linear-gradient(45deg,#39ff14,#ffe600);overflow:hidden;}
-    .pic-wrap video{width:100%;height:100%;border-radius:50%;object-fit:cover;}
-    .card .name{font-weight:bold;color:#ffd600;margin-bottom:4px;}
-    .badge{position:absolute;top:8px;right:8px;background:#39ff14;color:#000;padding:2px 6px;border-radius:4px;font-size:0.7rem;}
-    .actions{display:flex;flex-direction:column;gap:4px;margin-top:8px;}
-    .actions button{padding:6px;font-size:0.8rem;}
-    .btn{background:#1f2937;color:#e2e8f0;border:1px solid #334155;border-radius:6px;cursor:pointer;}
-    .btn:hover{background:#374151;}
-      #create{background:#39ff14;color:#000;border:none;padding:6px 10px;margin-right:8px;}
-      #createAI{background:#39ff14;color:#000;border:none;padding:6px 10px;}
-    .modal{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;z-index:9999;}
-    .modal.hidden{display:none;}
-    .modal-content{background:#111;padding:20px;border:2px solid #39ff14;border-radius:8px;max-height:80vh;overflow:auto;width:400px;}
-    .modal-content.glow{box-shadow:0 0 20px #39ff14;}
-    .modal-content h2{margin-top:0;color:#ffd600;}
-    .modal-content label{display:block;margin-top:10px;font-size:0.8rem;}
-    .modal-content input, .modal-content select{width:100%;padding:6px;margin-top:4px;background:#0b1220;color:#e2e8f0;border:1px solid #334155;border-radius:4px;}
-    .modal-content .form-actions{margin-top:12px;display:flex;gap:8px;justify-content:flex-end;}
+    body{
+      margin:0;
+      font-family:Arial,sans-serif;
+      background:#0a0a0a;
+      color:#e2e8f0;
+      overflow:hidden;
+    }
+    #bgGrid{
+      position:fixed;
+      inset:0;
+      background:
+        repeating-linear-gradient(0deg,transparent,transparent 24px,rgba(255,255,255,0.03) 24px,rgba(255,255,255,0.03) 25px),
+        repeating-linear-gradient(90deg,transparent,transparent 24px,rgba(255,255,255,0.03) 24px,rgba(255,255,255,0.03) 25px);
+      animation:moveGrid 40s linear infinite;
+      z-index:-1;
+    }
+    @keyframes moveGrid{
+      from{background-position:0 0,0 0;}
+      to{background-position:0 1000px,1000px 0;}
+    }
+    header.dashboard-header{
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      padding:1rem 1.25rem;
+    }
+    header.dashboard-header h1{
+      margin:0;
+      color:#4ade80;
+      text-shadow:0 0 8px #4ade80;
+      font-size:1.5rem;
+    }
+    header.dashboard-header .actions{display:flex;gap:.5rem;}
+    header.dashboard-header .actions .btn{background:#1f2937;border:1px solid #334155;border-radius:.5rem;padding:.5rem .75rem;cursor:pointer;}
+    header.dashboard-header .actions .btn:hover{background:#374151;}
+    .btn .icon{margin-right:4px;}
+    main{
+      height:calc(100vh - 70px);
+      overflow:auto;
+      padding:0 1.25rem 1.25rem;
+    }
+    .identity-grid{
+      display:grid;
+      grid-template-columns:repeat(auto-fill,minmax(200px,1fr));
+      gap:1rem;
+    }
+    .identity-card{
+      position:relative;
+      background:rgba(31,41,55,0.5);
+      backdrop-filter:blur(12px);
+      border:1px solid rgba(255,255,255,0.05);
+      border-radius:1rem;
+      padding:1rem;
+      text-align:center;
+      transition:transform .2s;
+    }
+    .identity-card:hover{transform:translateY(-4px);}
+    .identity-card .pic-wrap{
+      margin:0 auto .5rem;
+      width:72px;
+      height:72px;
+      border-radius:50%;
+      padding:3px;
+      background:linear-gradient(45deg,#4ade80,#a7f3d0);
+      overflow:hidden;
+    }
+    .identity-card .pic-wrap video{
+      width:100%;
+      height:100%;
+      border-radius:50%;
+      object-fit:cover;
+    }
+    .identity-card .name{font-weight:600;color:#e2e8f0;}
+    .identity-card .full{color:#9ca3af;font-size:.875rem;}
+    .identity-card .email{color:#9ca3af;font-size:.75rem;}
+    .identity-card .card-actions{
+      position:absolute;
+      top:.5rem;
+      right:.5rem;
+      display:flex;
+      gap:.25rem;
+      opacity:0;
+      transition:opacity .2s;
+    }
+    .identity-card:hover .card-actions{opacity:1;}
+    .card-actions button{
+      background:rgba(0,0,0,0.6);
+      border:none;
+      padding:4px;
+      border-radius:4px;
+      cursor:pointer;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .card-actions svg{width:16px;height:16px;color:#e2e8f0;}
+    .actions{margin-top:.75rem;}
+    .actions .btn{width:100%;}
+    .badge{position:absolute;top:.5rem;left:.5rem;background:#4ade80;color:#000;padding:2px 6px;border-radius:4px;font-size:.7rem;}
+    /* Sliding panel */
+    #identityPanel{
+      position:fixed;
+      top:0;
+      right:0;
+      width:100%;
+      max-width:420px;
+      height:100vh;
+      background:rgba(31,41,55,0.9);
+      backdrop-filter:blur(16px);
+      border-left:1px solid rgba(74,222,128,0.2);
+      box-shadow:0 0 30px rgba(74,222,128,0.1);
+      transform:translateX(100%);
+      transition:transform .4s ease-in-out;
+      display:flex;
+      flex-direction:column;
+      z-index:50;
+    }
+    #identityPanel.open{transform:translateX(0);}
+    #identityPanel header{
+      padding:1rem;
+      border-bottom:1px solid rgba(74,222,128,0.2);
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+    }
+    #identityPanel header h2{
+      margin:0;
+      color:#4ade80;
+    }
+    #identityPanel header button{
+      background:none;
+      border:none;
+      color:#e2e8f0;
+      font-size:1.25rem;
+      cursor:pointer;
+    }
+    #identityPanel main{flex:1;overflow:auto;padding:1rem;}
+    #identityPanel footer{padding:1rem;border-top:1px solid rgba(74,222,128,0.2);}
+    #identityPanel input,#identityPanel textarea,#identityPanel select{
+      width:100%;
+      padding:.5rem;
+      margin-top:.25rem;
+      background:rgba(255,255,255,0.05);
+      border:1px solid rgba(255,255,255,0.1);
+      border-radius:.5rem;
+      color:#e2e8f0;
+    }
+    #identityPanel input:focus,#identityPanel textarea:focus,#identityPanel select:focus{
+      outline:none;
+      border-color:#4ade80;
+      box-shadow:0 0 0 2px rgba(74,222,128,0.4);
+    }
+    #aiSetup textarea{height:120px;}
+    #aiSkeleton{margin-top:1rem;}
+    #aiSkeleton .line{height:40px;background:#374151;border-radius:.5rem;animation:pulse 1.5s infinite;}
+    @keyframes pulse{0%,100%{opacity:1;}50%{opacity:.5;}}
+    .hidden{display:none;}
   </style>
 </head>
 <body>
-  <video id="bgVideo" autoplay loop muted src="src/media/key.webm"></video>
-  <h1 class="zepra-gradient">Identities</h1>
-  <div>
-    <button id="create" class="btn">+ Create New Identity</button>
-    <button id="createAI" class="btn">+ Create with AI</button>
-  </div>
-  <div id="grid" class="grid"></div>
+  <div id="bgGrid"></div>
+  <header class="dashboard-header">
+    <h1>Identities</h1>
+    <div class="actions">
+      <button id="create" class="btn"><span class="icon">+</span><span>Create New Identity</span></button>
+      <button id="createAI" class="btn"><span class="icon">🤖</span><span>Create with AI</span></button>
+    </div>
+  </header>
+  <main>
+    <div id="grid" class="identity-grid"></div>
+  </main>
 
-  <!-- Identity Modal -->
-  <div id="identityModal" class="modal hidden">
-    <div class="modal-content">
-      <h2 id="modalTitle">New Identity</h2>
-      <form id="identityForm">
-        <input type="hidden" name="id">
-        <label>Identity Name<input name="identityName" required></label>
-        <label>Profile Picture URL<input name="profilePictureUrl"></label>
-        <label>Full Name<input name="fullName"></label>
-        <label>First Name<input name="firstName"></label>
-        <label>Last Name<input name="lastName"></label>
-        <label>Age<input name="age"></label>
-        <label>Email<input name="email"></label>
-        <label>Username<input name="username"></label>
-        <label>Password<input name="password"></label>
-        <label>Phone<input name="phone"></label>
-        <label>MAC Address<input name="macAddress"></label>
-        <label>Address 1<input name="address1"></label>
-        <label>Address 2<input name="address2"></label>
-        <label>City<input name="city"></label>
-        <label>State<input name="state"></label>
-        <label>Zip Code<input name="zipCode"></label>
-        <label>Country<input name="country"></label>
-        <h3 style="margin-top:10px;">Company Info</h3>
-        <label>Company Name<input name="companyName"></label>
-        <label>Industry<input name="companyIndustry"></label>
-        <label>Company Size<input name="companySize"></label>
-        <label>Annual Revenue<input name="companyAnnualRevenue"></label>
-        <label>Website<input name="companyWebsite"></label>
-        <label>Company Address<input name="companyAddress"></label>
-        <div class="form-actions">
-          <button type="button" id="cancelIdentity" class="btn">Cancel</button>
-          <button type="submit" class="btn">Save</button>
+  <aside id="identityPanel">
+    <header>
+      <h2 id="panelTitle">Create New Identity</h2>
+      <button id="closePanel">&#x2715;</button>
+    </header>
+    <main>
+      <div id="aiSetup" class="hidden">
+        <textarea id="aiPrompt" placeholder="Describe the identity..."></textarea>
+        <button id="aiGenerate" class="btn" style="margin-top:0.5rem;">Generate with AI</button>
+        <div id="aiSkeleton" class="skeleton hidden">
+          <div class="line"></div>
+          <div class="line"></div>
+          <div class="line"></div>
         </div>
-      </form>
-    </div>
-  </div>
-
-  <!-- AI Create Modal -->
-  <div id="aiModal" class="modal hidden">
-    <div class="modal-content glow">
-      <h2>Create Identity with AI</h2>
-      <textarea id="aiPrompt" style="width:100%;height:120px;background:#0b1220;color:#e2e8f0;border:1px solid #334155;border-radius:4px;"></textarea>
-      <div class="form-actions" style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end;">
-        <button type="button" id="aiCancel" class="btn">Cancel</button>
-        <button type="button" id="aiGenerate" class="btn">Generate</button>
       </div>
-    </div>
-  </div>
+      <form id="identityForm" class="identity-form">
+        <input type="hidden" name="id" />
+        <label>Identity Name<input name="identityName" required /></label>
+        <label>Profile Picture URL<input name="profilePictureUrl" /></label>
+        <label>Full Name<input name="fullName" /></label>
+        <label>First Name<input name="firstName" /></label>
+        <label>Last Name<input name="lastName" /></label>
+        <label>Age<input name="age" /></label>
+        <label>Email<input name="email" /></label>
+        <label>Username<input name="username" /></label>
+        <label>Password<input name="password" /></label>
+        <label>Phone<input name="phone" /></label>
+        <label>MAC Address<input name="macAddress" /></label>
+        <label>Address 1<input name="address1" /></label>
+        <label>Address 2<input name="address2" /></label>
+        <label>City<input name="city" /></label>
+        <label>State<input name="state" /></label>
+        <label>Zip Code<input name="zipCode" /></label>
+        <label>Country<input name="country" /></label>
+        <h3 style="margin-top:10px;">Company Info</h3>
+        <label>Company Name<input name="companyName" /></label>
+        <label>Industry<input name="companyIndustry" /></label>
+        <label>Company Size<input name="companySize" /></label>
+        <label>Annual Revenue<input name="companyAnnualRevenue" /></label>
+        <label>Website<input name="companyWebsite" /></label>
+        <label>Company Address<input name="companyAddress" /></label>
+      </form>
+    </main>
+    <footer>
+      <button type="submit" form="identityForm" class="btn primary" id="saveIdentity">Save Identity</button>
+    </footer>
+  </aside>
 
   <script src="identities.js"></script>
 </body>

--- a/RESUELV2/identities.js
+++ b/RESUELV2/identities.js
@@ -1,14 +1,15 @@
 const grid = document.getElementById('grid');
 const createBtn = document.getElementById('create');
 const createAIBtn = document.getElementById('createAI');
-const aiModal = document.getElementById('aiModal');
+const panel = document.getElementById('identityPanel');
+const panelTitle = document.getElementById('panelTitle');
+const closePanelBtn = document.getElementById('closePanel');
+const aiSetup = document.getElementById('aiSetup');
 const aiPrompt = document.getElementById('aiPrompt');
 const aiGenerate = document.getElementById('aiGenerate');
-const aiCancel = document.getElementById('aiCancel');
-const modal = document.getElementById('identityModal');
+const aiSkeleton = document.getElementById('aiSkeleton');
 const form = document.getElementById('identityForm');
-const cancelIdentity = document.getElementById('cancelIdentity');
-const modalTitle = document.getElementById('modalTitle');
+const saveIdentity = document.getElementById('saveIdentity');
 
 let identities = [];
 let activeId = null;
@@ -27,39 +28,53 @@ function load(){
 
 function render(){
   grid.innerHTML = '';
+  const editIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>';
+  const trashIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m5 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>';
   for(const id of identities){
     const card = document.createElement('div');
-    card.className = 'card' + (id.id===activeId ? ' active' : '');
+    card.className = 'identity-card' + (id.id===activeId ? ' active' : '');
     card.innerHTML = `
       ${id.id===activeId?'<div class="badge">Active</div>':''}
+      <div class="card-actions">
+        <button class="edit" title="Edit">${editIcon}</button>
+        <button class="del" title="Delete">${trashIcon}</button>
+      </div>
       <div class="pic-wrap"><video autoplay loop muted src="${id.profilePictureUrl||'src/media/zepra.webm'}"></video></div>
       <div class="name">${id.identityName||'No name'}</div>
-      <div>${id.country||''}</div>
-      <div class="actions">
-        <button class="btn act">${id.id===activeId?'Deactivate':'Activate'}</button>
-        <button class="btn edit">Edit</button>
-        <button class="btn del">Delete</button>
-      </div>
+      <div class="full">${id.fullName||''}</div>
+      <div class="email">${id.email||''}</div>
+      <div class="actions"><button class="btn act">${id.id===activeId?'Deactivate':'Activate'}</button></div>
     `;
     card.querySelector('.act').addEventListener('click',()=>toggleActive(id.id));
-    card.querySelector('.edit').addEventListener('click',()=>openForm(id));
+    card.querySelector('.edit').addEventListener('click',()=>openPanel(id));
     card.querySelector('.del').addEventListener('click',()=>remove(id.id));
     grid.appendChild(card);
   }
 }
 
-function openForm(data){
+function openPanel(data, mode='manual'){
   form.reset();
   form.id.value = data?.id || '';
   for(const k of Object.keys(data||{})){
     if(form[k]) form[k].value = data[k];
   }
-  modalTitle.textContent = data? 'Edit Identity' : 'New Identity';
-  modal.classList.remove('hidden');
+  if(mode==='ai'){
+    panelTitle.textContent = 'Create Identity with AI';
+    aiSetup.classList.remove('hidden');
+    form.classList.add('hidden');
+  } else {
+    panelTitle.textContent = data ? 'Edit Identity' : 'Create New Identity';
+    aiSetup.classList.add('hidden');
+    form.classList.remove('hidden');
+  }
+  panel.classList.add('open');
 }
 
-function closeForm(){
-  modal.classList.add('hidden');
+function closePanel(){
+  panel.classList.remove('open');
+  aiSetup.classList.add('hidden');
+  aiSkeleton.classList.add('hidden');
+  form.classList.remove('hidden');
 }
 
 function remove(id){
@@ -95,21 +110,20 @@ form.addEventListener('submit', e=>{
     obj.id = uid();
     identities.push(obj);
   }
-  closeForm();
+  closePanel();
   save();
   render();
 });
-
-cancelIdentity.addEventListener('click', closeForm);
-createBtn.addEventListener('click', ()=>openForm());
+createBtn.addEventListener('click', ()=>openPanel());
 createAIBtn.addEventListener('click', ()=>{
   aiPrompt.value='';
-  aiModal.classList.remove('hidden');
+  openPanel({}, 'ai');
 });
-aiCancel.addEventListener('click', ()=>aiModal.classList.add('hidden'));
+closePanelBtn.addEventListener('click', closePanel);
 aiGenerate.addEventListener('click', async () => {
   const prompt = aiPrompt.value.trim();
   if (!prompt) return;
+  aiSkeleton.classList.remove('hidden');
   try {
     const res = await chrome.runtime.sendMessage({ type: 'GENERATE_IDENTITY', prompt });
     if (!res?.ok) throw new Error('fetch');
@@ -119,12 +133,14 @@ aiGenerate.addEventListener('click', async () => {
     } catch (e) {
       console.error('Zepra Debug: Failed to parse AI response. Raw response was:', res?.result);
       alert('Error: AI provided an invalid response format.');
+      aiSkeleton.classList.add('hidden');
       return;
     }
     data.profilePictureUrl = '';
-    openForm(data);
-    aiModal.classList.add('hidden');
+    aiSkeleton.classList.add('hidden');
+    openPanel(data, 'manual');
   } catch (e) {
+    aiSkeleton.classList.add('hidden');
     alert('Error: Could not connect to the AI service. Please check your API key and network connection.');
   }
 });

--- a/RESUELV2/login.html
+++ b/RESUELV2/login.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Login - Zepra</title>
+  <title>Zepra Login</title>
   <link rel="stylesheet" href="styles.css" />
   <script src="theme.js"></script>
   <style>
@@ -81,8 +81,10 @@
       color: #0b1215;
       font-weight: 600;
       cursor: pointer;
+      transition: transform 0.2s;
     }
-    button:hover { filter: brightness(1.1); }
+    button:hover { filter: brightness(1.1); transform: translateY(-2px) scale(1.02); }
+    button:active { transform: scale(0.98); }
     #loginError {
       margin-top: 12px;
       text-align: center;
@@ -95,11 +97,12 @@
   <div class="box">
     <div id="headerWrap" class="header-video"><video id="headerVideo" autoplay loop muted src="src/media/key.webm"></video></div>
     <h1 class="zepra-gradient">Zepra</h1>
-    <input type="email" id="email" placeholder="Email" />
-    <input type="password" id="password" placeholder="Password" />
-    <button id="loginBtn">Login</button>
+    <input type="email" id="email" placeholder="Enter your email" />
+    <input type="password" id="password" placeholder="Enter your password" />
+    <button id="loginBtn">Access Zepra</button>
     <div id="loginError"></div>
   </div>
   <script src="login.js"></script>
 </body>
 </html>
+

--- a/RESUELV2/login.js
+++ b/RESUELV2/login.js
@@ -19,14 +19,12 @@ const successSound = new Audio(chrome.runtime.getURL('src/media/success.mp3'));
 
 function switchHeader(src){
   if(!headerWrap) return;
-  const removeLoader = window.showLoadingIndicator ? window.showLoadingIndicator(headerWrap) : () => {};
   const newVid = document.createElement('video');
   newVid.autoplay = true;
   newVid.loop = true;
   newVid.muted = true;
   newVid.src = src;
   newVid.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;object-fit:contain;opacity:0;transition:opacity 0.6s';
-  newVid.addEventListener('loadeddata', removeLoader, {once:true});
   headerWrap.appendChild(newVid);
   requestAnimationFrame(()=>{ newVid.style.opacity = 1; });
   if(headerVideo){
@@ -37,7 +35,29 @@ function switchHeader(src){
   }
 }
 
-// Redirect if already logged in and show any logout message
+window.performLogin = async (email, password) => {
+  if (!email || !password) {
+    return { success: false, message: 'Please enter email and password' };
+  }
+  try {
+    const res = await fetch(`https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${firebaseConfig.apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, returnSecureToken: true })
+    });
+    const data = await res.json();
+    if (data.error) throw new Error(data.error.message);
+    await chrome.storage.local.set({
+      loggedIn: true,
+      userEmail: email,
+      loginTime: Date.now()
+    });
+    return { success: true };
+  } catch (e) {
+    return { success: false, message: 'Invalid email or password' };
+  }
+};
+
 chrome.storage.local.get(['loggedIn', 'logoutMsg'], ({ loggedIn, logoutMsg }) => {
   if (loggedIn) {
     window.location.href = 'popup.html';
@@ -50,35 +70,19 @@ chrome.storage.local.get(['loggedIn', 'logoutMsg'], ({ loggedIn, logoutMsg }) =>
 
 btn.addEventListener('click', async () => {
   clickSound.play();
-  const email = emailEl.value.trim();
-  const password = passEl.value;
   msg.textContent = '';
   msg.style.color = 'var(--warn)';
-  if (!email || !password) {
-    msg.textContent = 'Please enter email and password';
-    return;
-  }
-  try {
-    const res = await fetch(`https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${firebaseConfig.apiKey}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password, returnSecureToken: true })
-      });
-    const data = await res.json();
-    if (data.error) throw new Error(data.error.message);
-    await chrome.storage.local.set({
-      loggedIn: true,
-      userEmail: email,
-      loginTime: Date.now()
-    });
+  const email = emailEl.value.trim();
+  const password = passEl.value;
+  const res = await window.performLogin(email, password);
+  if (res.success) {
     msg.style.color = 'var(--accent)';
     msg.textContent = 'Logged in successfully!';
     successSound.play();
     switchHeader('src/media/zepra.webm');
     setTimeout(() => { window.location.href = 'popup.html'; }, 800);
-  } catch (e) {
+  } else {
     switchHeader('src/media/carry.webm');
-    msg.textContent = 'Invalid email or password';
+    msg.textContent = res.message;
   }
 });


### PR DESCRIPTION
## Summary
- revert popup to original card-based Zepra dashboard with user bar, icon toolbar, and network info
- futurize IP Qualification modal with animated radar ring and status-driven coloring
- modernize custom site view with centered glass frame, icon-only controls, and floating particle backdrop
- unify Fake User Info into a glassy modal with skeleton loading, icon tooltips, and regenerate button
- revamp Identities page into a neon dashboard with card grid and sliding create panel

## Testing
- `npm test` *(fails: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/Resuelv/package.json`)*
- `npm run build` *(fails: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/Resuelv/package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_68c4a5c2f674832f91bc75994cb8d42b