### PR TITLE
Add plan outlines and multi-step execution for survey agent

### DIFF
--- a/zepra/RESUELV2/background.js
+++ b/zepra/RESUELV2/background.js
@@ -3,10 +3,22 @@
 // - OCR via OCR.space
 // - Public IP via ipdata with fallback services
 
+importScripts('src/agent/actions.js', 'src/agent/planner.js');
+
+const surveyAgentActions = self.surveyAgentActions || null;
+const surveyAgentPlanner = self.surveyAgentPlanner || null;
+
 const DEFAULTS = {
   cerebrasModel: 'gpt-oss-120b',
   typingSpeed: 'normal', // fast | normal | slow
   ocrLang: 'eng',
+  cerebrasBaseUrl: 'https://api.cerebras.ai/v1',
+  cerebrasTimeoutMs: 60 * 1000,
+  cerebrasTemperature: 0.2,
+  cerebrasMaxTokens: 1024,
+  surveyPlannerPromptTemplate: typeof self.SURVEY_AGENT_DEFAULT_PROMPT_TEMPLATE === 'string'
+    ? self.SURVEY_AGENT_DEFAULT_PROMPT_TEMPLATE
+    : ''
 };
 
 const SESSION_DURATION = 3 * 60 * 60 * 1000; // 3 hours
@@ -116,6 +128,128 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         case 'CEREBRAS_GENERATE': {
           const result = await callCerebras(message.prompt);
           sendResponse({ ok: true, result });
+          break;
+        }
+        case 'SURVEY_AGENT_REQUEST_DOM': {
+          const targetTabId = message.tabId || sender?.tab?.id || (await getActiveTabId());
+          if (!targetTabId) {
+            sendResponse({ ok: false, error: 'NO_ACTIVE_TAB' });
+            break;
+          }
+          try {
+            const domResponse = await chrome.tabs.sendMessage(targetTabId, {
+              type: 'SURVEY_AGENT_COLLECT_DOM',
+              options: message.options || {}
+            });
+            if (domResponse && domResponse.ok && domResponse.tree) {
+              sendResponse({ ok: true, tree: domResponse.tree });
+            } else {
+              sendResponse({ ok: false, error: domResponse?.error || 'DOM_TREE_UNAVAILABLE' });
+            }
+          } catch (err) {
+            sendResponse({ ok: false, error: err?.message || String(err) });
+          }
+          break;
+        }
+        case 'SURVEY_AGENT_EXECUTE_ACTION': {
+          const targetTabId = message.tabId || sender?.tab?.id || (await getActiveTabId());
+          if (!targetTabId) {
+            sendResponse({ ok: false, error: 'NO_ACTIVE_TAB' });
+            break;
+          }
+          if (!surveyAgentActions || typeof surveyAgentActions.execute !== 'function') {
+            sendResponse({ ok: false, error: 'SURVEY_ACTIONS_UNAVAILABLE' });
+            break;
+          }
+          try {
+            const result = await surveyAgentActions.execute(targetTabId, message.action || {});
+            sendResponse(result);
+          } catch (err) {
+            sendResponse({
+              ok: false,
+              error: err?.message || String(err),
+              code: err?.code,
+              details: err?.details,
+            });
+          }
+          break;
+        }
+        case 'SURVEY_AGENT_EXECUTE_BATCH': {
+          const targetTabId = message.tabId || sender?.tab?.id || (await getActiveTabId());
+          if (!targetTabId) {
+            sendResponse({ ok: false, error: 'NO_ACTIVE_TAB' });
+            break;
+          }
+          if (!surveyAgentActions || typeof surveyAgentActions.execute !== 'function') {
+            sendResponse({ ok: false, error: 'SURVEY_ACTIONS_UNAVAILABLE' });
+            break;
+          }
+          const steps = Array.isArray(message.steps) ? message.steps : [];
+          const stopOnFailure = message.stopOnFailure !== false;
+          const results = [];
+          let overallOk = true;
+          for (const step of steps) {
+            const result = await surveyAgentActions.execute(targetTabId, step || {});
+            results.push(result);
+            if (!result?.ok) {
+              overallOk = false;
+              if (stopOnFailure) break;
+            }
+          }
+          sendResponse({ ok: overallOk, results });
+          break;
+        }
+        case 'SURVEY_AGENT_PLAN_NEXT': {
+          if (!surveyAgentPlanner || typeof surveyAgentPlanner.planNext !== 'function') {
+            sendResponse({ ok: false, error: 'SURVEY_PLANNER_UNAVAILABLE' });
+            break;
+          }
+          try {
+            const result = await surveyAgentPlanner.planNext({
+              domTree: message.domTree,
+              history: Array.isArray(message.history) ? message.history : [],
+              goal: message.goal,
+              instructions: message.instructions,
+              options: message.options,
+              context: message.context,
+              conversation: message.conversation,
+            });
+            sendResponse(result);
+          } catch (err) {
+            sendResponse({
+              ok: false,
+              error: err?.message || String(err),
+              code: err?.code,
+              details: err?.details,
+            });
+          }
+          break;
+        }
+        case 'SURVEY_AGENT_GET_DEFAULT_PROMPT_TEMPLATE': {
+          sendResponse({
+            ok: true,
+            template: typeof self.SURVEY_AGENT_DEFAULT_PROMPT_TEMPLATE === 'string'
+              ? self.SURVEY_AGENT_DEFAULT_PROMPT_TEMPLATE
+              : ''
+          });
+          break;
+        }
+        case 'SURVEY_AGENT_SAVE_HISTORY': {
+          const record = message.record;
+          if (!record || typeof record !== 'object') {
+            sendResponse({ ok: false, error: 'INVALID_HISTORY_RECORD' });
+            break;
+          }
+          try {
+            const key = 'surveyAgentHistory';
+            const stored = await chrome.storage.local.get(key);
+            const list = Array.isArray(stored[key]) ? stored[key] : [];
+            const next = [record, ...list].slice(0, 25);
+            await chrome.storage.local.set({ [key]: next });
+            sendResponse({ ok: true, total: next.length });
+          } catch (err) {
+            sendResponse({ ok: false, error: err?.message || String(err) });
+          }
           break;
         }
         case 'CAPTURE_AND_OCR': {
@@ -286,8 +420,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 async function callCerebras(prompt) {
-  const { cerebrasApiKey = '', cerebrasModel } = await chrome.storage.local.get([
-    'cerebrasApiKey', 'cerebrasModel'
+  const {
+    cerebrasApiKey = '',
+    cerebrasModel,
+    cerebrasBaseUrl,
+    cerebrasTimeoutMs,
+    cerebrasTemperature,
+    cerebrasMaxTokens
+  } = await chrome.storage.local.get([
+    'cerebrasApiKey',
+    'cerebrasModel',
+    'cerebrasBaseUrl',
+    'cerebrasTimeoutMs',
+    'cerebrasTemperature',
+    'cerebrasMaxTokens'
   ]);
   if (!cerebrasApiKey) {
     const e = new Error('Missing Cerebras API key (set it in Options).');
@@ -295,29 +441,83 @@ async function callCerebras(prompt) {
     throw e;
   }
   const model = cerebrasModel || DEFAULTS.cerebrasModel;
-  const endpoint = 'https://api.cerebras.ai/v1/chat/completions';
+  const baseUrl = (cerebrasBaseUrl || DEFAULTS.cerebrasBaseUrl || 'https://api.cerebras.ai/v1').trim();
+  const timeout = Number.isFinite(cerebrasTimeoutMs) && cerebrasTimeoutMs > 0
+    ? cerebrasTimeoutMs
+    : DEFAULTS.cerebrasTimeoutMs || 60000;
+  const temperature = Number.isFinite(cerebrasTemperature)
+    ? Math.min(Math.max(cerebrasTemperature, 0), 2)
+    : (DEFAULTS.cerebrasTemperature ?? 0.2);
+  const maxTokens = Number.isFinite(cerebrasMaxTokens) && cerebrasMaxTokens > 0
+    ? Math.round(cerebrasMaxTokens)
+    : (DEFAULTS.cerebrasMaxTokens ?? 1024);
+
+  let endpoint = baseUrl;
+  if (!/\/chat\/completions$/i.test(endpoint)) {
+    endpoint = endpoint.replace(/\/$/, '') + '/chat/completions';
+  }
   const body = {
     model,
     messages: [{ role: 'user', content: prompt }],
-    temperature: 0.2,
-    max_completion_tokens: 1024
+    temperature
   };
+  if (maxTokens) {
+    body.max_completion_tokens = maxTokens;
+  }
   const headers = {
     'Content-Type': 'application/json',
     'Authorization': `Bearer ${cerebrasApiKey}`
   };
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+  let timeoutId;
   try {
-    const res = await fetch(endpoint, { method: 'POST', headers, body: JSON.stringify(body) });
+    if (controller && timeout) {
+      timeoutId = setTimeout(() => controller.abort(), timeout);
+    }
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller ? controller.signal : undefined
+    });
     if (!res.ok) {
-      const t = await res.text().catch(() => '');
-      throw new Error(`Cerebras error ${res.status}: ${t}`);
+      const raw = await res.text().catch(() => '');
+      let parsed;
+      try {
+        parsed = raw ? JSON.parse(raw) : null;
+      } catch (parseErr) {
+        parsed = null;
+      }
+      const err = new Error(`Cerebras error ${res.status}: ${raw}`);
+      if (res.status === 429) {
+        err.code = 'CEREBRAS_RATE_LIMIT';
+      } else if (res.status === 401 || res.status === 403) {
+        err.code = 'CEREBRAS_AUTH';
+      }
+      if (parsed && typeof parsed === 'object') {
+        err.details = parsed;
+        if (!err.code && typeof parsed.code === 'string') {
+          err.code = parsed.code;
+        }
+      }
+      throw err;
     }
     const data = await res.json();
     const text = data?.choices?.[0]?.message?.content || data?.choices?.[0]?.delta?.content || '';
     return sanitize(text);
   } catch (err) {
+    if (err?.name === 'AbortError') {
+      const timeoutError = new Error(`Cerebras request timed out after ${timeout} ms`);
+      timeoutError.code = 'CEREBRAS_TIMEOUT';
+      console.error('Zepra Debug: Cerebras fetch timed out');
+      throw timeoutError;
+    }
     console.error('Zepra Debug: Cerebras fetch failed:', err);
     throw err;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 

--- a/zepra/RESUELV2/content.js
+++ b/zepra/RESUELV2/content.js
@@ -19,7 +19,51 @@ function init() {
     selBtn: null,
     lastFocused: null,
     lastMouse: { x: 20, y: 20 },
-    fillIcon: null
+    fillIcon: null,
+    surveyAgent: {
+      domTree: null,
+      highlightLookup: new Map(),
+      nodeById: new Map(),
+      parentById: new Map(),
+      lastUpdated: 0,
+      ocrCache: new Map(),
+      ocrCacheUrl: '',
+      settings: {
+        useIdentityAnswers: true,
+        deliberateMode: false,
+      },
+      session: {
+        running: false,
+        stopRequested: false,
+        status: 'idle',
+        history: [],
+        logs: [],
+        chat: [],
+        startedAt: 0,
+        completedAt: 0,
+        planCount: 0,
+        errorCount: 0,
+        maxSteps: 40,
+        instructions: '',
+        goal: '',
+        loopPromise: null,
+        rateLimitBackoffMs: 0,
+        currentPhase: null,
+        lastPlanSignature: '',
+        lastExecutedSignature: '',
+        repeatPlanCount: 0,
+        repeatedSuccessCount: 0,
+        lastPlanAt: 0,
+        lastActionAt: 0,
+        statusMessage: 'في انتظار تعليماتك.',
+        statusTone: 'status',
+      },
+      ui: {
+        modal: null,
+        styleEl: null,
+        elements: null,
+      },
+    }
   };
 
   let customPrompts = [];
@@ -27,6 +71,3421 @@ function init() {
   chrome.storage.onChanged.addListener((chg, area) => {
     if(area === 'sync' && chg.customPrompts){ customPrompts = chg.customPrompts.newValue || []; }
   });
+
+  let activeIdentity = null;
+
+  function getSurveyAgentSettings() {
+    if (!STATE.surveyAgent.settings) {
+      STATE.surveyAgent.settings = { useIdentityAnswers: true, deliberateMode: false };
+    }
+    return STATE.surveyAgent.settings;
+  }
+
+  function applySurveyAgentSettings(settings = {}) {
+    const target = getSurveyAgentSettings();
+    target.useIdentityAnswers = settings.useIdentityAnswers !== false;
+    target.deliberateMode = Boolean(settings.deliberateMode);
+    syncSurveyAgentSettingsToUi();
+  }
+
+  function persistSurveyAgentSettings(settings = {}) {
+    const payload = {
+      useIdentityAnswers: settings.useIdentityAnswers !== false,
+      deliberateMode: Boolean(settings.deliberateMode),
+    };
+    try {
+      chrome.storage.local.set({ [SURVEY_AGENT_SETTINGS_KEY]: payload }, () => {
+        if (chrome.runtime?.lastError) {
+          console.warn('Survey agent settings save failed', chrome.runtime.lastError);
+        }
+      });
+    } catch (err) {
+      console.warn('Survey agent settings persistence error', err);
+    }
+  }
+
+  function loadSurveyAgentSettings() {
+    try {
+      chrome.storage.local.get(SURVEY_AGENT_SETTINGS_KEY, (res) => {
+        const stored = res && res[SURVEY_AGENT_SETTINGS_KEY];
+        if (stored && typeof stored === 'object') {
+          applySurveyAgentSettings(stored);
+        } else {
+          applySurveyAgentSettings(getSurveyAgentSettings());
+        }
+      });
+    } catch (err) {
+      console.warn('Survey agent settings load error', err);
+    }
+  }
+
+  function updateSurveyAgentSetting(key, value) {
+    const settings = getSurveyAgentSettings();
+    settings[key] = value;
+    persistSurveyAgentSettings(settings);
+    syncSurveyAgentSettingsToUi();
+  }
+
+  function syncSurveyAgentSettingsToUi() {
+    const settings = getSurveyAgentSettings();
+    const ui = getSurveyAgentUiState();
+    const elements = ui.elements || {};
+    if (elements.identityToggle) {
+      elements.identityToggle.checked = settings.useIdentityAnswers !== false;
+    }
+    if (elements.deliberateToggle) {
+      elements.deliberateToggle.checked = Boolean(settings.deliberateMode);
+    }
+  }
+
+  loadSurveyAgentSettings();
+
+  let domBuilderModulePromise = null;
+
+  function resolveDomBuilderFromGlobals() {
+    const builder =
+      (globalThis.__zepraBuildDomTreeModule && globalThis.__zepraBuildDomTreeModule.buildDomTree) ||
+      globalThis.__zepraBuildDomTree ||
+      globalThis.buildDomTree;
+    if (typeof builder !== 'function') return null;
+    const module = { buildDomTree: builder };
+    try {
+      if (!globalThis.__zepraBuildDomTreeModule) {
+        globalThis.__zepraBuildDomTreeModule = module;
+      }
+      if (!globalThis.__zepraBuildDomTree) {
+        globalThis.__zepraBuildDomTree = builder;
+      }
+    } catch (err) {
+      // Ignore strict CSP frames that block global assignment
+    }
+    return module;
+  }
+
+  function loadDomBuilderModule() {
+    if (domBuilderModulePromise) return domBuilderModulePromise;
+
+    const existing = resolveDomBuilderFromGlobals();
+    if (existing) {
+      domBuilderModulePromise = Promise.resolve(existing);
+      return domBuilderModulePromise;
+    }
+
+    domBuilderModulePromise = new Promise((resolve, reject) => {
+      const startedAt = Date.now();
+      const timeoutMs = 5000;
+
+      const poll = () => {
+        const module = resolveDomBuilderFromGlobals();
+        if (module) {
+          resolve(module);
+          return;
+        }
+        if (Date.now() - startedAt > timeoutMs) {
+          reject(new Error('DOM builder unavailable'));
+          return;
+        }
+        setTimeout(poll, 50);
+      };
+
+      poll();
+    }).catch((err) => {
+      domBuilderModulePromise = null;
+      throw err;
+    });
+
+    return domBuilderModulePromise;
+  }
+
+  async function collectSurveyDomTree(options = {}) {
+    const allowCache = !options?.forceRefresh && !options?.showHighlights && !options?.debugMode;
+    const state = STATE.surveyAgent;
+    const now = Date.now();
+
+    if (
+      allowCache &&
+      state.domTree &&
+      state.lastUpdated &&
+      now - state.lastUpdated <= SURVEY_AGENT_DOM_CACHE_TTL
+    ) {
+      return state.domTree;
+    }
+
+    if (allowCache && !state.domTree) {
+      const cached = loadSurveyAgentDomCache();
+      if (cached && cached.tree) {
+        const refreshedTimestamp = Date.now();
+        updateSurveyAgentDomCache(cached.tree, { timestamp: refreshedTimestamp, persist: allowCache });
+        try {
+          await augmentSurveyAgentDomTree(cached.tree, options);
+        } catch (err) {
+          console.warn('Survey agent cache augment failed', err);
+        }
+        return state.domTree;
+      }
+    }
+
+    const module = await loadDomBuilderModule();
+    if (!module || typeof module.buildDomTree !== 'function') {
+      throw new Error('DOM builder unavailable');
+    }
+    const {
+      showHighlights = false,
+      focusHighlightIndex = -1,
+      viewportExpansion = 0,
+      startHighlightIndex = 0,
+      startId = 0,
+      debugMode = false
+    } = options || {};
+
+    const tree = await module.buildDomTree({
+      showHighlightElements: Boolean(showHighlights),
+      focusHighlightIndex: Number.isInteger(focusHighlightIndex) ? focusHighlightIndex : -1,
+      viewportExpansion: Number.isFinite(viewportExpansion) ? viewportExpansion : 0,
+      startHighlightIndex: Number.isInteger(startHighlightIndex) ? startHighlightIndex : 0,
+      startId: Number.isInteger(startId) ? startId : 0,
+      debugMode: Boolean(debugMode)
+    });
+
+    updateSurveyAgentDomCache(tree, { persist: allowCache });
+
+    await augmentSurveyAgentDomTree(tree, options);
+
+    return tree;
+  }
+
+  function updateSurveyAgentDomCache(tree, meta = {}) {
+    const { highlightLookup, nodeById, parentById } = buildSurveyAgentLookups(tree);
+    const timestamp = meta.timestamp || Date.now();
+    STATE.surveyAgent.domTree = tree || null;
+    STATE.surveyAgent.highlightLookup = highlightLookup;
+    STATE.surveyAgent.nodeById = nodeById;
+    STATE.surveyAgent.parentById = parentById;
+    STATE.surveyAgent.lastUpdated = timestamp;
+
+    if (meta.persist) {
+      storeSurveyAgentDomCache(tree, timestamp);
+    }
+
+    try {
+      window.__zepraSurveyAgentCache = {
+        lastUpdated: STATE.surveyAgent.lastUpdated,
+        highlightIndices: Array.from(highlightLookup.keys()),
+      };
+    } catch (e) {
+      // Ignore serialization issues
+    }
+  }
+
+  function getSurveyAgentDomCacheStorageKey() {
+    try {
+      const url = new URL(window.location.href);
+      url.hash = '';
+      return `${SURVEY_AGENT_DOM_CACHE_STORAGE_KEY}${url.origin}${url.pathname}`;
+    } catch (err) {
+      return `${SURVEY_AGENT_DOM_CACHE_STORAGE_KEY}${window.location.href.split('#')[0]}`;
+    }
+  }
+
+  function loadSurveyAgentDomCache() {
+    const key = getSurveyAgentDomCacheStorageKey();
+    try {
+      const raw = sessionStorage.getItem(key);
+      if (!raw) return null;
+      const payload = JSON.parse(raw);
+      if (!payload || typeof payload !== 'object' || !payload.tree) return null;
+      if (payload.version !== 1) return null;
+      if (payload.url && payload.url !== window.location.href.split('#')[0]) return null;
+      if (typeof payload.timestamp === 'number') {
+        if (Date.now() - payload.timestamp > SURVEY_AGENT_DOM_CACHE_PERSIST_TTL) {
+          sessionStorage.removeItem(key);
+          return null;
+        }
+      }
+      if (
+        typeof payload.viewportWidth === 'number' &&
+        payload.viewportWidth !== window.innerWidth
+      ) {
+        return null;
+      }
+      if (
+        typeof payload.viewportHeight === 'number' &&
+        Math.abs(payload.viewportHeight - window.innerHeight) > 40
+      ) {
+        return null;
+      }
+      return payload;
+    } catch (err) {
+      try {
+        sessionStorage.removeItem(key);
+      } catch (cleanupErr) {
+        // ignore cleanup errors
+      }
+      return null;
+    }
+  }
+
+  function storeSurveyAgentDomCache(tree, timestamp) {
+    if (!tree) return;
+    const key = getSurveyAgentDomCacheStorageKey();
+    const payload = {
+      version: 1,
+      url: window.location.href.split('#')[0],
+      timestamp: timestamp || Date.now(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      tree,
+    };
+    try {
+      sessionStorage.setItem(key, JSON.stringify(payload));
+    } catch (err) {
+      try {
+        sessionStorage.removeItem(key);
+      } catch (cleanupErr) {
+        // ignore cleanup
+      }
+    }
+  }
+
+  function invalidateSurveyAgentDomCache(options = {}) {
+    STATE.surveyAgent.domTree = null;
+    STATE.surveyAgent.highlightLookup = new Map();
+    STATE.surveyAgent.nodeById = new Map();
+    STATE.surveyAgent.parentById = new Map();
+    STATE.surveyAgent.lastUpdated = 0;
+    if (!options.skipStorage) {
+      try {
+        sessionStorage.removeItem(getSurveyAgentDomCacheStorageKey());
+      } catch (err) {
+        // ignore removal failures
+      }
+    }
+  }
+
+  function buildSurveyAgentLookups(tree) {
+    const highlightLookup = new Map();
+    const nodeById = new Map();
+    const parentById = new Map();
+
+    if (!tree || typeof tree !== 'object' || !tree.map) {
+      return { highlightLookup, nodeById, parentById };
+    }
+
+    const entries = Object.entries(tree.map);
+    for (const [id, node] of entries) {
+      nodeById.set(id, node);
+      if (node && Array.isArray(node.children)) {
+        for (const childId of node.children) {
+          parentById.set(childId, id);
+        }
+      }
+    }
+
+    const buildFrameChain = (nodeId) => {
+      const chain = [];
+      let currentId = parentById.get(nodeId);
+      while (currentId) {
+        const parentNode = nodeById.get(currentId);
+        if (!parentNode) break;
+        if ((parentNode.tagName || '').toLowerCase() === 'iframe') {
+          chain.unshift({
+            nodeId: currentId,
+            xpath: parentNode.xpath || '',
+            attributes: parentNode.attributes || {},
+          });
+        }
+        currentId = parentById.get(currentId);
+      }
+      return chain;
+    };
+
+    for (const [id, node] of nodeById.entries()) {
+      if (node && Number.isInteger(node.highlightIndex)) {
+        highlightLookup.set(node.highlightIndex, {
+          nodeId: id,
+          xpath: node.xpath || '',
+          tagName: node.tagName || '',
+          attributes: node.attributes || {},
+          frameChain: buildFrameChain(id),
+        });
+      }
+    }
+
+    return { highlightLookup, nodeById, parentById };
+  }
+
+  function formatIdentityPreviewValue(value, max = 80) {
+    if (value == null) return '';
+    const text = String(value).trim();
+    if (!text) return '';
+    return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+  }
+
+  function getActiveIdentitySnapshot() {
+    if (!activeIdentity || typeof activeIdentity !== 'object') return null;
+    const snapshot = {};
+    const push = (key, value) => {
+      if (snapshot[key]) return;
+      if (typeof value !== 'string') return;
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      snapshot[key] = trimmed;
+    };
+    for (const key of SURVEY_AGENT_IDENTITY_FIELD_ORDER) {
+      if (Object.prototype.hasOwnProperty.call(activeIdentity, key)) {
+        push(key, activeIdentity[key]);
+      }
+    }
+    if (Object.keys(snapshot).length < 12) {
+      for (const [key, value] of Object.entries(activeIdentity)) {
+        if (snapshot[key]) continue;
+        if (/^(id|profilePictureUrl)$/i.test(key)) continue;
+        push(key, value);
+        if (Object.keys(snapshot).length >= 24) break;
+      }
+    }
+    return Object.keys(snapshot).length ? snapshot : null;
+  }
+
+  function buildLocatorForNode(nodeId, node) {
+    const locator = {};
+    if (Number.isInteger(node?.highlightIndex)) locator.highlightIndex = node.highlightIndex;
+    if (nodeId) locator.nodeId = String(nodeId);
+    if (node?.xpath) locator.xpath = node.xpath;
+    if (Array.isArray(node?.frameChain)) locator.frameChain = node.frameChain;
+    return locator;
+  }
+
+  function shouldAttemptAutoOcr(node) {
+    if (!node || typeof node !== 'object') return false;
+    const tag = (node.tagName || '').toLowerCase();
+    if (tag !== 'img' && tag !== 'svg' && tag !== 'canvas') return false;
+    if (node.isVisible === false) return false;
+    if (typeof node.ocrText === 'string' && node.ocrText.length) return false;
+    const attrs = node.attributes || {};
+    const alt = typeof attrs.alt === 'string' ? attrs.alt.trim() : '';
+    const aria = typeof attrs['aria-label'] === 'string' ? attrs['aria-label'].trim() : '';
+    if ((alt && alt.length > 3) || (aria && aria.length > 3)) return false;
+    return true;
+  }
+
+  function annotateIdentityHintsOnTree(tree) {
+    const snapshot = getActiveIdentitySnapshot();
+    const map = tree?.map;
+    if (!map) return;
+    const eligible = new Set(['input', 'textarea', 'select']);
+    for (const [nodeId, node] of Object.entries(map)) {
+      if (!node || typeof node !== 'object') continue;
+      const tag = (node.tagName || '').toLowerCase();
+      if (!eligible.has(tag)) {
+        if (node.identityKey) {
+          delete node.identityKey;
+          delete node.identityPreview;
+        }
+        continue;
+      }
+      const locator = buildLocatorForNode(nodeId, node);
+      const resolved = resolveSurveyAgentElement(locator);
+      const element = resolved.element;
+      if (!element) {
+        if (node.identityKey) {
+          delete node.identityKey;
+          delete node.identityPreview;
+        }
+        continue;
+      }
+      const key = detectField(element);
+      if (key) {
+        node.identityKey = key;
+        if (snapshot && snapshot[key]) {
+          node.identityPreview = formatIdentityPreviewValue(snapshot[key]);
+        } else {
+          delete node.identityPreview;
+        }
+      } else if (node.identityKey) {
+        delete node.identityKey;
+        delete node.identityPreview;
+      }
+    }
+  }
+
+  async function annotateSurveyImagesWithOcr(tree, options = {}) {
+    const map = tree?.map;
+    if (!map) return;
+    const state = STATE.surveyAgent;
+    if (!state.ocrCache || !(state.ocrCache instanceof Map)) {
+      state.ocrCache = new Map();
+    }
+    const cache = state.ocrCache;
+    const targets = [];
+    for (const [nodeId, node] of Object.entries(map)) {
+      if (!shouldAttemptAutoOcr(node)) continue;
+      const cacheKey = node.xpath || `${nodeId}`;
+      if (cache.has(cacheKey)) {
+        const cached = cache.get(cacheKey);
+        if (typeof cached === 'string' && cached.trim()) {
+          node.ocrText = cached;
+        }
+        continue;
+      }
+      targets.push({ nodeId, node, cacheKey });
+    }
+    if (!targets.length) return;
+    const slice = targets.slice(0, SURVEY_AGENT_MAX_AUTO_OCR);
+    const settings = await chrome.storage.local.get('ocrLang');
+    const ocrLang = settings?.ocrLang || 'eng';
+    const tabId = await getTabId();
+    for (const target of slice) {
+      const locator = buildLocatorForNode(target.nodeId, target.node);
+      const resolved = resolveSurveyAgentElement(locator);
+      const element = resolved.element;
+      if (!element) {
+        cache.set(target.cacheKey, '');
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      if (!rect) {
+        cache.set(target.cacheKey, '');
+        continue;
+      }
+      if (
+        rect.width < SURVEY_AGENT_OCR_MIN_EDGE ||
+        rect.height < SURVEY_AGENT_OCR_MIN_EDGE ||
+        rect.bottom < 0 ||
+        rect.top > window.innerHeight ||
+        rect.right < 0 ||
+        rect.left > window.innerWidth
+      ) {
+        cache.set(target.cacheKey, '');
+        continue;
+      }
+      try {
+        const response = await chrome.runtime.sendMessage({
+          type: 'CAPTURE_AND_OCR',
+          rect: {
+            x: rect.left,
+            y: rect.top,
+            width: rect.width,
+            height: rect.height,
+            dpr: window.devicePixelRatio || 1,
+          },
+          tabId,
+          ocrLang,
+        });
+        if (response?.ok && response.text) {
+          const text = String(response.text).trim();
+          if (text) {
+            target.node.ocrText = text;
+            cache.set(target.cacheKey, text);
+          } else {
+            cache.set(target.cacheKey, '');
+          }
+        } else {
+          cache.set(target.cacheKey, '');
+        }
+      } catch (err) {
+        console.warn('Survey agent OCR error', err);
+        cache.set(target.cacheKey, '');
+      }
+      await sleep(120);
+    }
+  }
+
+  async function augmentSurveyAgentDomTree(tree, options = {}) {
+    if (!tree || typeof tree !== 'object' || !tree.map) return;
+    const state = STATE.surveyAgent;
+    if (state.ocrCacheUrl !== location.href) {
+      state.ocrCache = new Map();
+      state.ocrCacheUrl = location.href;
+    }
+    try {
+      annotateIdentityHintsOnTree(tree);
+    } catch (err) {
+      console.warn('Survey agent identity annotation failed', err);
+    }
+    try {
+      await annotateSurveyImagesWithOcr(tree, options);
+    } catch (err) {
+      console.warn('Survey agent OCR annotation failed', err);
+    }
+  }
+
+  function summarizeSurveyAgentProgress(tree) {
+    const map = tree && tree.map ? tree.map : null;
+    if (!map) return null;
+    let total = 0;
+    let filled = 0;
+    let required = 0;
+    let requiredFilled = 0;
+    const missing = [];
+    for (const node of Object.values(map)) {
+      if (!node || typeof node !== 'object') continue;
+      const tag = (node.tagName || '').toLowerCase();
+      if (!['input', 'textarea', 'select'].includes(tag)) continue;
+      total += 1;
+      const isRequired = Boolean(
+        node.isRequired ||
+          (node.attributes &&
+            (node.attributes.required !== undefined ||
+              (typeof node.attributes['aria-required'] === 'string' && node.attributes['aria-required'].toLowerCase() === 'true')))
+      );
+      if (isRequired) required += 1;
+      const hasValue = Boolean(
+        (typeof node.currentValue === 'string' && node.currentValue.trim()) ||
+          (Array.isArray(node.selectedTexts) && node.selectedTexts.some((text) => text && text.trim())) ||
+          (Array.isArray(node.selectedValues) && node.selectedValues.some((value) => value && String(value).trim())) ||
+          node.isChecked === true
+      );
+      if (hasValue) filled += 1;
+      if (isRequired && hasValue) {
+        requiredFilled += 1;
+      } else if (isRequired && !hasValue) {
+        const highlight = Number.isInteger(node.highlightIndex) ? `#${node.highlightIndex}` : '';
+        const identityHint = node.identityKey ? node.identityKey : '';
+        const nameAttr = node.attributes?.name || node.attributes?.id || '';
+        const descriptor = highlight || identityHint || nameAttr || (node.xpath ? node.xpath.slice(-24) : tag);
+        missing.push(descriptor);
+      }
+    }
+    if (!total) return null;
+    return {
+      totalFields: total,
+      filledFields: filled,
+      requiredFields: required,
+      requiredFilled,
+      missingRequired: missing.slice(0, 8),
+    };
+  }
+
+  function formatSurveyAgentProgress(progress) {
+    if (!progress) return '';
+    const parts = [];
+    parts.push(`${progress.filledFields}/${progress.totalFields} fields filled`);
+    if (progress.requiredFields) {
+      parts.push(`required ${progress.requiredFilled}/${progress.requiredFields}`);
+    }
+    if (Array.isArray(progress.missingRequired) && progress.missingRequired.length) {
+      parts.push(`missing required: ${progress.missingRequired.join(', ')}`);
+    }
+    return parts.join(' • ');
+  }
+
+  function buildSurveyAgentPlanningContext(domTree, session) {
+    const identitySnapshot = getActiveIdentitySnapshot();
+    const preview = identitySnapshot
+      ? Object.fromEntries(
+          Object.entries(identitySnapshot).map(([key, value]) => [key, formatIdentityPreviewValue(value)])
+        )
+      : null;
+    const context = {
+      page: {
+        url: location.href,
+        title: document.title,
+      },
+      preferences: {
+        useIdentityAnswers: session ? session.useIdentityAnswers !== false : true,
+        deliberateMode: session ? Boolean(session.deliberateMode) : false,
+      },
+    };
+    const docLang = document.documentElement?.lang;
+    if (docLang) {
+      context.page.language = docLang;
+    } else if (navigator.language) {
+      context.page.language = navigator.language;
+    }
+    const progress = summarizeSurveyAgentProgress(domTree);
+    if (progress) {
+      context.progress = progress;
+      context.page.formProgress = formatSurveyAgentProgress(progress);
+    }
+    if (identitySnapshot) {
+      context.identity = identitySnapshot;
+      context.identityPreview = preview;
+    }
+    return context;
+  }
+
+  function buildSurveyAgentPlannerOptions(session) {
+    const deliberate = session ? Boolean(session.deliberateMode) : false;
+    return {
+      maxNodes: deliberate ? 160 : 120,
+      preferences: {
+        useIdentityAnswers: session ? session.useIdentityAnswers !== false : true,
+        deliberateMode: deliberate,
+      },
+    };
+  }
+
+  async function ensureSurveyAgentPlanSpacing(session) {
+    if (!session) return;
+    const cooldown = SURVEY_AGENT_PLAN_COOLDOWN_BASE + (session.deliberateMode ? SURVEY_AGENT_PLAN_COOLDOWN_DELIBERATE : 0);
+    if (!session.lastPlanAt) {
+      if (session.deliberateMode) {
+        await sleep(SURVEY_AGENT_POST_ACTION_DELAY_DELIBERATE);
+      }
+      return;
+    }
+    const elapsed = Date.now() - session.lastPlanAt;
+    if (elapsed < cooldown) {
+      const jitter = rand(40, 140);
+      await sleep(cooldown - elapsed + jitter);
+    }
+  }
+
+  const SURVEY_AGENT_SETTINGS_KEY = 'surveyAgentSettings';
+  const SURVEY_AGENT_DEFAULT_GOAL = 'أكمل المهمة المطلوبة بعناية.';
+  const SURVEY_AGENT_MAX_PLAN_ERRORS = 3;
+  const SURVEY_AGENT_MAX_LOGS = 80;
+  const SURVEY_AGENT_HISTORY_LIMIT = 12;
+  const SURVEY_AGENT_MAX_CHAT_MESSAGES = 60;
+  const SURVEY_AGENT_CHAT_CONTEXT_LIMIT = 12;
+  const SURVEY_AGENT_MAX_AUTO_OCR = 4;
+  const SURVEY_AGENT_OCR_MIN_EDGE = 24;
+  const SURVEY_AGENT_REPEAT_STUCK_LIMIT = 1;
+  const SURVEY_AGENT_PLAN_REPEAT_LIMIT = 3;
+  const SURVEY_AGENT_RATE_LIMIT_BACKOFF_INITIAL = 1500;
+  const SURVEY_AGENT_RATE_LIMIT_BACKOFF_MAX = 15000;
+  const SURVEY_AGENT_PLAN_COOLDOWN_BASE = 520;
+  const SURVEY_AGENT_PLAN_COOLDOWN_DELIBERATE = 1500;
+  const SURVEY_AGENT_POST_ACTION_DELAY_OK = 240;
+  const SURVEY_AGENT_POST_ACTION_DELAY_FAIL = 520;
+  const SURVEY_AGENT_POST_ACTION_DELAY_DELIBERATE = 300;
+  const SURVEY_AGENT_DOM_CACHE_TTL = 1200;
+  const SURVEY_AGENT_DOM_CACHE_PERSIST_TTL = 5000;
+  const SURVEY_AGENT_DOM_CACHE_STORAGE_KEY = '__zepraSurveyDomCacheV1__';
+  const SURVEY_AGENT_IDENTITY_FIELD_ORDER = [
+    'identityName',
+    'fullName',
+    'firstName',
+    'lastName',
+    'username',
+    'password',
+    'email',
+    'phone',
+    'age',
+    'address1',
+    'address2',
+    'city',
+    'state',
+    'zipCode',
+    'country',
+    'companyName',
+    'companyIndustry',
+    'companySize',
+    'companyAnnualRevenue',
+    'companyWebsite',
+    'companyAddress',
+    'macAddress',
+  ];
+
+  function getSurveyAgentSession() {
+    return STATE.surveyAgent.session;
+  }
+
+  function getSurveyAgentUiState() {
+    return STATE.surveyAgent.ui;
+  }
+
+  function ensureSurveyAgentStyles() {
+    const ui = getSurveyAgentUiState();
+    if (ui.styleEl && ui.styleEl.isConnected) return;
+    const style = document.createElement('style');
+    style.id = 'zepra-survey-agent-styles';
+    style.textContent = `
+      #zepra-survey-agent-panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100vh;
+        width: min(420px, 100vw);
+        z-index: 2147483646;
+        display: flex;
+        transform: translateX(110%);
+        transition: transform 0.28s ease, box-shadow 0.28s ease;
+        pointer-events: none;
+      }
+
+      #zepra-survey-agent-panel.is-open {
+        transform: translateX(0);
+        pointer-events: auto;
+        box-shadow: -28px 0 48px rgba(11, 16, 33, 0.58);
+      }
+
+      #zepra-survey-agent-panel.is-closing {
+        pointer-events: none;
+      }
+
+      #zepra-survey-agent-panel .nano-agent-window {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        background: linear-gradient(180deg, rgba(15, 23, 42, 0.94), rgba(7, 12, 24, 0.96));
+        backdrop-filter: blur(26px);
+        border-left: 1px solid rgba(125, 211, 252, 0.14);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 30px 60px -40px rgba(15, 23, 42, 0.95);
+        color: #e8f1ff;
+        font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+        letter-spacing: 0.01em;
+      }
+
+      #zepra-survey-agent-panel .nano-agent-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 1.15rem 1.5rem 1rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+        background: linear-gradient(135deg, rgba(30, 41, 59, 0.82), rgba(17, 24, 39, 0.92));
+        backdrop-filter: blur(24px);
+        box-shadow: inset 0 -1px 0 rgba(6, 11, 23, 0.8);
+      }
+
+      #zepra-survey-agent-panel .nano-brand {
+        display: flex;
+        align-items: center;
+        gap: 0.9rem;
+      }
+
+      #zepra-survey-agent-panel .nano-logo {
+        width: 40px;
+        height: 40px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #60a5fa, #38bdf8);
+        color: #041021;
+        font-size: 1.1rem;
+        font-weight: 700;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        letter-spacing: 0.08em;
+        box-shadow: 0 22px 44px -26px rgba(56, 189, 248, 0.85);
+      }
+
+      #zepra-survey-agent-panel .nano-heading {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+
+      #zepra-survey-agent-panel .nano-title {
+        font-weight: 600;
+        font-size: 1.05rem;
+        color: #f1f7ff;
+        letter-spacing: 0.02em;
+      }
+
+      #zepra-survey-agent-panel .nano-status-line {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      #zepra-survey-agent-panel .nano-status-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        border-radius: 999px;
+        padding: 0.24rem 0.7rem;
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        background: rgba(30, 41, 59, 0.6);
+        color: rgba(226, 232, 240, 0.82);
+        font-size: 0.74rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      #zepra-survey-agent-panel .nano-status-badge::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: currentColor;
+        box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.16);
+      }
+
+      #zepra-survey-agent-panel .nano-status-badge.is-running {
+        border-color: rgba(56, 189, 248, 0.4);
+        background: rgba(14, 165, 233, 0.22);
+        color: #7dd3fc;
+      }
+
+      #zepra-survey-agent-panel .nano-status-badge.is-success {
+        border-color: rgba(74, 222, 128, 0.35);
+        background: rgba(22, 163, 74, 0.26);
+        color: #bbf7d0;
+      }
+
+      #zepra-survey-agent-panel .nano-status-badge.is-error {
+        border-color: rgba(248, 113, 113, 0.34);
+        background: rgba(153, 27, 27, 0.32);
+        color: #fecaca;
+      }
+
+      #zepra-survey-agent-panel .nano-status-badge.is-warning {
+        border-color: rgba(253, 224, 71, 0.34);
+        background: rgba(202, 138, 4, 0.32);
+        color: #fde68a;
+      }
+
+      #zepra-survey-agent-panel .nano-status-text {
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(203, 213, 225, 0.68);
+      }
+
+      #zepra-survey-agent-panel .nano-header-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      #zepra-survey-agent-panel .nano-run-toggle {
+        border-radius: 0.9rem;
+        border: 1px solid rgba(59, 130, 246, 0.35);
+        padding: 0.46rem 1.05rem;
+        background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(56, 189, 248, 0.28));
+        color: #dbeafe;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-weight: 600;
+        font-size: 0.72rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease;
+      }
+
+      #zepra-survey-agent-panel .nano-run-toggle.is-stop {
+        border-color: rgba(248, 113, 113, 0.38);
+        background: linear-gradient(135deg, rgba(248, 113, 113, 0.28), rgba(244, 63, 94, 0.2));
+        color: #fecaca;
+      }
+
+      #zepra-survey-agent-panel .nano-run-toggle:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      #zepra-survey-agent-panel .nano-run-toggle:not(:disabled):hover {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 28px -20px rgba(37, 99, 235, 0.6);
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.45), rgba(56, 189, 248, 0.32));
+      }
+
+      #zepra-survey-agent-panel .survey-agent-close {
+        background: transparent;
+        border: none;
+        color: rgba(149, 191, 255, 0.68);
+        width: 34px;
+        height: 34px;
+        border-radius: 12px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.35rem;
+        line-height: 1;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+
+      #zepra-survey-agent-panel .survey-agent-close:hover {
+        background: rgba(30, 64, 175, 0.42);
+        color: #fff;
+      }
+
+      #zepra-survey-agent-panel .nano-controls {
+        padding: 12px 18px 10px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        background: rgba(11, 24, 45, 0.68);
+        border-top: 1px solid rgba(59, 130, 246, 0.1);
+        border-bottom: 1px solid rgba(56, 189, 248, 0.12);
+      }
+
+      #zepra-survey-agent-panel .nano-toggle {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+        font-size: 0.82rem;
+        color: rgba(224, 231, 255, 0.82);
+        line-height: 1.45;
+      }
+
+      #zepra-survey-agent-panel .nano-toggle input[type="checkbox"] {
+        margin-top: 2px;
+        width: 16px;
+        height: 16px;
+        accent-color: #5eead4;
+      }
+
+      #zepra-survey-agent-panel .nano-toggle span {
+        flex: 1;
+      }
+
+      #zepra-survey-agent-panel .nano-thread {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1.35rem 1.5rem;
+        overflow-y: auto;
+        scroll-behavior: smooth;
+      }
+
+      #zepra-survey-agent-panel .nano-placeholder {
+        margin-top: 3rem;
+        text-align: center;
+        color: rgba(203, 213, 225, 0.6);
+        font-size: 0.94rem;
+        line-height: 1.6;
+      }
+
+      #zepra-survey-agent-panel .nano-messages {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      #zepra-survey-agent-panel .nano-message {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.85rem;
+      }
+
+      #zepra-survey-agent-panel .nano-avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 14px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        font-size: 0.78rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        box-shadow: 0 18px 36px -26px rgba(15, 118, 255, 0.9);
+      }
+
+      #zepra-survey-agent-panel .nano-avatar.is-agent {
+        background: linear-gradient(135deg, rgba(45, 212, 191, 0.3), rgba(14, 165, 233, 0.38));
+        color: #ecfeff;
+      }
+
+      #zepra-survey-agent-panel .nano-avatar.is-user {
+        background: linear-gradient(135deg, rgba(79, 70, 229, 0.32), rgba(59, 130, 246, 0.38));
+        color: #e0e7ff;
+      }
+
+      #zepra-survey-agent-panel .nano-bubble {
+        flex: 1;
+        background: linear-gradient(160deg, rgba(11, 22, 45, 0.9), rgba(6, 16, 34, 0.92));
+        border: 1px solid rgba(96, 165, 250, 0.35);
+        border-radius: 1.1rem;
+        padding: 0.85rem 1.05rem;
+        color: #e9f2ff;
+        line-height: 1.6;
+        position: relative;
+        box-shadow: 0 24px 46px -32px rgba(59, 130, 246, 0.55);
+      }
+
+      #zepra-survey-agent-panel .nano-message.is-agent .nano-bubble {
+        border-color: rgba(45, 212, 191, 0.35);
+        box-shadow: 0 24px 46px -30px rgba(45, 212, 191, 0.55);
+      }
+
+      #zepra-survey-agent-panel .nano-message[data-meta="error"] .nano-bubble {
+        border-color: rgba(248, 113, 113, 0.4);
+        background: linear-gradient(160deg, rgba(67, 20, 36, 0.9), rgba(88, 28, 58, 0.92));
+        color: #fecaca;
+      }
+
+      #zepra-survey-agent-panel .nano-message[data-meta="warning"] .nano-bubble {
+        border-color: rgba(253, 224, 71, 0.4);
+        background: linear-gradient(160deg, rgba(80, 57, 16, 0.9), rgba(113, 63, 18, 0.92));
+        color: #fde68a;
+      }
+
+      #zepra-survey-agent-panel .nano-message[data-meta="plan"] .nano-bubble {
+        border-color: rgba(96, 165, 250, 0.42);
+        background: linear-gradient(160deg, rgba(17, 34, 68, 0.92), rgba(13, 26, 54, 0.94));
+      }
+
+      #zepra-survey-agent-panel .nano-message-meta {
+        margin-top: 0.45rem;
+        font-size: 0.72rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(191, 219, 254, 0.5);
+      }
+
+      #zepra-survey-agent-panel .nano-compose {
+        padding: 1.15rem 1.5rem 1.45rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.16);
+        background: linear-gradient(180deg, rgba(8, 15, 30, 0.94), rgba(6, 12, 24, 0.98));
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      #zepra-survey-agent-panel .nano-compose textarea {
+        width: 100%;
+        min-height: 64px;
+        border-radius: 1rem;
+        border: 1px solid rgba(96, 165, 250, 0.28);
+        background: rgba(12, 19, 36, 0.78);
+        color: #f1f5ff;
+        padding: 0.9rem 1.05rem;
+        resize: vertical;
+        font-family: inherit;
+        font-size: 0.95rem;
+        line-height: 1.6;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      #zepra-survey-agent-panel .nano-compose textarea::placeholder {
+        color: rgba(148, 163, 184, 0.65);
+      }
+
+      #zepra-survey-agent-panel .nano-compose textarea:focus {
+        outline: none;
+        border-color: rgba(56, 189, 248, 0.6);
+        box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.38), 0 18px 38px -32px rgba(56, 189, 248, 0.6);
+      }
+
+      #zepra-survey-agent-panel .nano-compose footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.85rem;
+      }
+
+      #zepra-survey-agent-panel .nano-compose .nano-hint {
+        font-size: 0.72rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(203, 213, 225, 0.58);
+      }
+
+      #zepra-survey-agent-panel .nano-compose .nano-send {
+        border-radius: 0.95rem;
+        padding: 0.65rem 1.25rem;
+        border: none;
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 165, 233, 0.95));
+        color: #f0f9ff;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+      }
+
+      #zepra-survey-agent-panel .nano-compose .nano-send:disabled {
+        opacity: 0.42;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      #zepra-survey-agent-panel .nano-compose .nano-send:not(:disabled):hover {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 32px -24px rgba(59, 130, 246, 0.85);
+      }
+
+      #zepra-survey-agent-panel .nano-thread::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      #zepra-survey-agent-panel .nano-thread::-webkit-scrollbar-track {
+        background: rgba(8, 20, 45, 0.78);
+      }
+
+      #zepra-survey-agent-panel .nano-thread::-webkit-scrollbar-thumb {
+        background: rgba(88, 136, 226, 0.45);
+        border-radius: 999px;
+      }
+
+      #zepra-survey-agent-panel .nano-thread::-webkit-scrollbar-thumb:hover {
+        background: rgba(110, 162, 255, 0.58);
+      }
+
+      @media (max-width: 600px) {
+        #zepra-survey-agent-panel {
+          width: 100vw;
+        }
+
+        #zepra-survey-agent-panel .nano-agent-header,
+        #zepra-survey-agent-panel .nano-thread,
+        #zepra-survey-agent-panel .nano-compose {
+          padding-left: 1rem;
+          padding-right: 1rem;
+        }
+      }
+
+    `;
+    document.head.appendChild(style);
+    ui.styleEl = style;
+  }
+  function formatTimeShort(ts) {
+    try {
+      return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function renderSurveyAgentChat() {
+    const session = getSurveyAgentSession();
+    const ui = getSurveyAgentUiState();
+    const elements = ui.elements || {};
+    const thread = elements.chatThread;
+    if (!thread) return;
+
+    const chatBody = elements.chatBody;
+    const chatEmpty = elements.chatEmpty;
+    thread.innerHTML = '';
+
+    const chat = Array.isArray(session.chat) ? session.chat : [];
+    if (!chat.length) {
+      thread.style.display = 'none';
+      if (chatEmpty) chatEmpty.style.display = 'block';
+      if (chatBody) chatBody.scrollTop = 0;
+      return;
+    }
+
+    thread.style.display = 'flex';
+    if (chatEmpty) chatEmpty.style.display = 'none';
+
+    chat.forEach((entry) => {
+      if (!entry || typeof entry.text !== 'string') return;
+      const role = entry.role === 'agent' || entry.role === 'system' ? 'agent' : 'user';
+      const item = document.createElement('div');
+      item.className = `nano-message is-${role}`;
+      if (entry.meta) {
+        item.dataset.meta = entry.meta;
+      } else {
+        delete item.dataset.meta;
+      }
+
+      const avatar = document.createElement('div');
+      avatar.className = `nano-avatar is-${role}`;
+      avatar.textContent = role === 'agent' ? 'A' : 'YOU';
+      item.appendChild(avatar);
+
+      const bubble = document.createElement('div');
+      bubble.className = 'nano-bubble';
+      bubble.textContent = entry.text;
+      item.appendChild(bubble);
+
+      if (entry.timestamp) {
+        const stamp = document.createElement('div');
+        stamp.className = 'nano-message-meta';
+        stamp.textContent = formatTimeShort(entry.timestamp);
+        item.appendChild(stamp);
+      }
+
+      thread.appendChild(item);
+    });
+
+    if (chatBody) {
+      chatBody.scrollTop = chatBody.scrollHeight;
+    }
+  }
+
+  function appendSurveyAgentChatMessage(message) {
+    if (!message || typeof message.text !== 'string') return;
+    const text = message.text.trim();
+    if (!text) return;
+    const session = getSurveyAgentSession();
+    if (!Array.isArray(session.chat)) session.chat = [];
+    const entry = {
+      id: message.id || `chat-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      role: message.role === 'agent' || message.role === 'system' ? message.role : 'user',
+      text,
+      timestamp: Number.isFinite(message.timestamp) ? message.timestamp : Date.now(),
+    };
+    if (message.meta) {
+      entry.meta = message.meta;
+    }
+    session.chat.push(entry);
+    if (session.chat.length > SURVEY_AGENT_MAX_CHAT_MESSAGES) {
+      session.chat.splice(0, session.chat.length - SURVEY_AGENT_MAX_CHAT_MESSAGES);
+    }
+    renderSurveyAgentChat();
+  }
+
+  const SURVEY_AGENT_STATUS_METAS = new Set(['status', 'plan', 'warning', 'error', 'progress']);
+  const SURVEY_AGENT_CHAT_METAS = new Set([
+    'chat',
+    'reply',
+    'ask',
+    'summary',
+    'greeting',
+    'ack',
+    'ack-running',
+    'ack-idle',
+    'operator',
+    'plan-outline',
+    'progress-update',
+  ]);
+
+  function setSurveyAgentStatusMessage(text, tone = 'status') {
+    const session = getSurveyAgentSession();
+    if (!session) return;
+    const message = typeof text === 'string' ? text.trim() : '';
+    const nextTone = tone || 'status';
+    if (session.statusMessage === message && session.statusTone === nextTone) {
+      return;
+    }
+    session.statusMessage = message;
+    session.statusTone = nextTone;
+    updateSurveyAgentUiState();
+  }
+
+  function appendSurveyAgentChatAck(text, meta = 'ack') {
+    const session = getSurveyAgentSession();
+    if (!text) return;
+    const chat = Array.isArray(session.chat) ? session.chat : [];
+    const last = chat[chat.length - 1];
+    if (last && last.role === 'agent' && last.meta === meta && last.text === text) {
+      return;
+    }
+    appendSurveyAgentChatMessage({ role: 'agent', text, meta });
+  }
+
+  function getLastAgentMessage(session) {
+    if (!session || !Array.isArray(session.chat)) return null;
+    for (let idx = session.chat.length - 1; idx >= 0; idx -= 1) {
+      const entry = session.chat[idx];
+      if (entry && entry.role === 'agent') {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  function appendSurveyAgentAgentMessage(text, meta = 'status') {
+    if (!text) return;
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const session = getSurveyAgentSession();
+    if (SURVEY_AGENT_STATUS_METAS.has(meta)) {
+      setSurveyAgentStatusMessage(trimmed, meta);
+      return;
+    }
+    const lastAgent = getLastAgentMessage(session);
+    const chatMeta = SURVEY_AGENT_CHAT_METAS.has(meta) ? meta : 'chat';
+    if (lastAgent && lastAgent.text === trimmed && lastAgent.meta === chatMeta) {
+      return;
+    }
+    appendSurveyAgentChatMessage({ role: 'agent', text: trimmed, meta: chatMeta });
+  }
+
+  function updateSurveyAgentPhase(session, phase, message, meta = 'status') {
+    if (!session) return;
+    if (session.currentPhase === phase) {
+      if (message) {
+        appendSurveyAgentAgentMessage(message, meta);
+      }
+      return;
+    }
+    session.currentPhase = phase;
+    if (message) {
+      appendSurveyAgentAgentMessage(message, meta);
+    }
+  }
+
+  function ensureSurveyAgentChatGreeting() {
+    const session = getSurveyAgentSession();
+    if (Array.isArray(session.chat) && session.chat.length) return;
+    appendSurveyAgentChatMessage({
+      role: 'agent',
+      text: 'أهلاً! ازاي أقدر أساعدك؟',
+      meta: 'greeting',
+    });
+  }
+
+  function handleSurveyAgentChatSubmit() {
+    const ui = getSurveyAgentUiState();
+    const input = ui.elements && ui.elements.chatInput;
+    if (!input) return;
+    const value = input.value.trim();
+    if (!value) return;
+    const session = getSurveyAgentSession();
+    const shouldAutoStart = !session.running;
+    sendSurveyAgentUserMessage(value);
+    input.value = '';
+    if (ui.elements && ui.elements.chatSend) {
+      ui.elements.chatSend.disabled = true;
+    }
+    input.focus();
+    if (shouldAutoStart) {
+      startSurveyAgentRun({ instructions: value });
+    }
+  }
+
+  function sendSurveyAgentUserMessage(text) {
+    const session = getSurveyAgentSession();
+    appendSurveyAgentChatMessage({ role: 'user', text, meta: 'operator' });
+    appendSurveyAgentLog({ level: 'info', label: 'Operator', message: text });
+    if (text && typeof text === 'string') {
+      session.instructions = text;
+      session.goal = text;
+    }
+    if (session.running) {
+      appendSurveyAgentChatAck('تمام، هنفذ ده حالاً.', 'ack-running');
+      setSurveyAgentStatusMessage('مستمر في تنفيذ المطلوب.', 'plan');
+    } else {
+      appendSurveyAgentChatAck('تمام، هابدأ دلوقتي.', 'ack-idle');
+    }
+  }
+
+  function buildSurveyAgentPlannerConversation(limit = SURVEY_AGENT_CHAT_CONTEXT_LIMIT) {
+    const session = getSurveyAgentSession();
+    const chat = Array.isArray(session.chat) ? session.chat : [];
+    if (!chat.length) return [];
+    const slice = chat.slice(-Math.max(3, limit));
+    return slice
+      .filter((entry) => entry && typeof entry.text === 'string' && entry.text.trim())
+      .map((entry) => ({
+        role: entry.role === 'agent' ? 'agent' : entry.role === 'system' ? 'system' : 'user',
+        text: entry.text.trim(),
+        meta: entry.meta || undefined,
+        timestamp: entry.timestamp || Date.now(),
+      }));
+  }
+
+  function renderSurveyAgentLogs() {
+    const session = getSurveyAgentSession();
+    const ui = getSurveyAgentUiState();
+    const elements = ui.elements || {};
+    if (!elements.logList) return;
+
+    const { logList, logBody, emptyState } = elements;
+    logList.innerHTML = '';
+
+    if (!session.logs.length) {
+      if (emptyState) emptyState.style.display = 'flex';
+      logList.style.display = 'none';
+      if (logBody) logBody.scrollTop = 0;
+      return;
+    }
+
+    logList.style.display = 'flex';
+    if (emptyState) emptyState.style.display = 'none';
+
+    session.logs.forEach((entry) => {
+      const item = document.createElement('div');
+      item.className = `survey-agent-log-item level-${entry.level || 'info'}`;
+
+      const header = document.createElement('div');
+      header.className = 'survey-agent-log-item-header';
+
+      const label = document.createElement('span');
+      label.className = 'survey-agent-log-item-label';
+      label.textContent = entry.label || entry.level || 'info';
+
+      const time = document.createElement('span');
+      time.className = 'survey-agent-log-item-time';
+      time.textContent = formatTimeShort(entry.timestamp);
+
+      header.appendChild(label);
+      header.appendChild(time);
+      item.appendChild(header);
+
+      if (entry.message) {
+        const message = document.createElement('div');
+        message.className = 'survey-agent-log-item-message';
+        message.textContent = entry.message;
+        item.appendChild(message);
+      }
+
+      if (entry.detail) {
+        const detail = document.createElement('div');
+        detail.className = 'survey-agent-log-item-detail';
+        detail.textContent = entry.detail;
+        item.appendChild(detail);
+      }
+
+      logList.appendChild(item);
+    });
+
+    if (logBody) {
+      logBody.scrollTop = logBody.scrollHeight;
+    }
+  }
+
+  function surveyAgentStatusDescriptor(session) {
+    const steps = session.history.length;
+    const plans = session.planCount;
+    const stepLabel = steps === 1 ? 'خطوة' : 'خطوات';
+    const planLabel = plans === 1 ? 'خطة' : 'خطط';
+    const counts = `${steps} ${stepLabel} • ${plans} ${planLabel}`;
+    const toneRaw = session.statusTone || 'status';
+    const tone = toneRaw === 'warning' || toneRaw === 'error' ? toneRaw : 'status';
+    const statusMessage = session.statusMessage ? session.statusMessage : '';
+    const meta = statusMessage
+      ? counts
+        ? `${statusMessage} • ${counts}`
+        : statusMessage
+      : counts;
+
+    if (session.running && session.stopRequested) {
+      return { label: 'جاري الإيقاف', badge: 'is-warning', meta };
+    }
+
+    if (session.running) {
+      let label = 'قيد العمل';
+      let badge = 'is-running';
+      switch (session.status) {
+        case 'scanning':
+          label = 'مسح الصفحة';
+          break;
+        case 'planning':
+          label = 'تخطيط الحركة';
+          break;
+        case 'executing':
+          label = 'تنفيذ الخطوة';
+          break;
+        case 'review':
+          label = 'مراجعة التقدّم';
+          break;
+        case 'rate-limit':
+          label = 'تهدئة السرعة';
+          badge = 'is-warning';
+          break;
+        case 'loop-guard':
+          label = 'بحاجة لتوجيه';
+          badge = 'is-warning';
+          break;
+        default:
+          label = 'قيد العمل';
+          break;
+      }
+      if (tone === 'warning') {
+        badge = 'is-warning';
+      } else if (tone === 'error') {
+        badge = 'is-error';
+      }
+      return { label, badge, meta };
+    }
+
+    let label;
+    let badge;
+    switch (session.status) {
+      case 'done':
+        label = 'اكتمل';
+        badge = 'is-success';
+        break;
+      case 'aborted':
+        label = 'أُلغي';
+        badge = 'is-warning';
+        break;
+      case 'error':
+        label = 'خطأ';
+        badge = 'is-error';
+        break;
+      case 'stopped':
+        label = 'متوقف';
+        badge = 'is-warning';
+        break;
+      default:
+        label = 'جاهز';
+        badge = 'is-idle';
+        break;
+    }
+    if (tone === 'warning' && badge !== 'is-success') {
+      badge = 'is-warning';
+    } else if (tone === 'error') {
+      badge = 'is-error';
+    }
+    const fallbackMeta = statusMessage || 'في انتظار تعليماتك.';
+    return { label, badge, meta: statusMessage ? meta : `${fallbackMeta} • ${counts}` };
+  }
+
+  function updateSurveyAgentUiState() {
+    const session = getSurveyAgentSession();
+    const ui = getSurveyAgentUiState();
+    const elements = ui.elements;
+    if (!elements) return;
+
+    const descriptor = surveyAgentStatusDescriptor(session);
+    if (elements.statusBadge) {
+      elements.statusBadge.textContent = descriptor.label;
+      elements.statusBadge.classList.remove('is-running', 'is-success', 'is-warning', 'is-error');
+      if (descriptor.badge && descriptor.badge !== 'is-idle') {
+        elements.statusBadge.classList.add(descriptor.badge);
+      }
+    }
+
+    if (elements.statusText) {
+      elements.statusText.textContent = descriptor.meta || '';
+    }
+
+    if (elements.chatSend) {
+      const chatValue = elements.chatInput ? elements.chatInput.value.trim() : '';
+      elements.chatSend.disabled = !chatValue;
+    }
+
+    renderSurveyAgentChat();
+  }
+
+  function truncateForLog(str, max = 72) {
+    if (!str) return '';
+    const value = String(str);
+    return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+  }
+
+  function appendSurveyAgentLog(entry) {
+    const session = getSurveyAgentSession();
+    const logEntry = {
+      id: entry.id || `log-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      level: entry.level || 'info',
+      label: entry.label || '',
+      message: entry.message || '',
+      detail: entry.detail || '',
+      timestamp: entry.timestamp || Date.now(),
+    };
+    session.logs.push(logEntry);
+    if (session.logs.length > SURVEY_AGENT_MAX_LOGS) {
+      session.logs.splice(0, session.logs.length - SURVEY_AGENT_MAX_LOGS);
+    }
+    updateSurveyAgentUiState();
+  }
+
+  function formatSurveyAgentAction(step) {
+    if (!step || typeof step !== 'object') return '';
+    const type = String(step.type || '').toLowerCase();
+    const hi = step.locator && Number.isInteger(step.locator.highlightIndex) ? `#${step.locator.highlightIndex}` : '';
+    if (type === 'click') {
+      return hi ? `نقر العنصر ${hi}` : 'نقر عنصر';
+    }
+    if (type === 'type') {
+      const text = truncateForLog(step.text || step.value || '');
+      return hi ? `كتابة "${text}" في ${hi}` : `كتابة "${text}"`;
+    }
+    if (type === 'select') {
+      const text = truncateForLog(step.text || step.option || '');
+      return hi ? `اختيار "${text}" من ${hi}` : `اختيار الخيار "${text}"`;
+    }
+    if (type === 'scroll') {
+      if (step.mode === 'percent') {
+        return `تمرير حتى ${step.percent ?? 0}%`;
+      }
+      if (step.mode === 'top') return 'تمرير لأعلى الصفحة';
+      if (step.mode === 'bottom') return 'تمرير لأسفل الصفحة';
+      return hi ? `تمرير العنصر ${hi} داخل الشاشة` : 'تمرير الصفحة';
+    }
+    if (type === 'navigate') {
+      const url = truncateForLog(step.url || '');
+      return `الانتقال إلى ${url || 'الرابط المطلوب'}`;
+    }
+    if (type === 'back') return 'رجوع للخلف';
+    if (type === 'forward') return 'تقدم للأمام';
+    if (type === 'reload') return 'إعادة تحميل الصفحة';
+    if (type === 'dom_scan') {
+      return 'مسح هيكل الصفحة';
+    }
+    if (type === 'ocr_capture') {
+      return 'تشغيل OCR للعنصر المحدد';
+    }
+    if (type === 'wait') {
+      const ms = Number.isFinite(step.ms) ? step.ms : Number(step.duration) || 0;
+      return `انتظار ${Math.max(0, Math.round(ms))} مللي ثانية`;
+    }
+    if (type === 'status') return 'تحديث شريط الحالة';
+    if (type === 'ip_info') return 'عرض معلومات الـIP';
+    if (type === 'ip_check') return 'تشغيل فحص تأهيل الـIP';
+    if (type === 'custom_open') return 'فتح نافذة المساعدة الخارجية';
+    if (type === 'open_tab') {
+      const url = truncateForLog(step.url || '');
+      return `فتح تبويب جديد ${url ? `(${url})` : ''}`.trim();
+    }
+    if (type === 'note_save') {
+      const title = truncateForLog(step.title || '');
+      return title ? `حفظ ملاحظة «${title}»` : 'حفظ ملاحظة جديدة';
+    }
+    return type ? `خطوة ${type}` : 'خطوة';
+  }
+
+  function formatSurveyAgentActionEnglish(step) {
+    if (!step || typeof step !== 'object') return '';
+    const type = String(step.type || '').toLowerCase();
+    const locator = step.locator || {};
+    const hasHighlight = Number.isInteger(locator.highlightIndex);
+    const target = hasHighlight ? `element #${locator.highlightIndex}` : 'the target element';
+    const textValue = typeof step.text === 'string' ? step.text : typeof step.value === 'string' ? step.value : '';
+    const identityMatch = typeof textValue === 'string' ? textValue.match(/\{\{IDENTITY\.([^}]+)\}\}/i) : null;
+    const identityLabel = identityMatch ? identityMatch[1] : '';
+    const truncated = textValue ? truncateForLog(textValue, 64) : '';
+    switch (type) {
+      case 'click':
+        return hasHighlight ? `Click ${target}` : 'Click the target element';
+      case 'type':
+        if (identityLabel) {
+          return hasHighlight
+            ? `Fill ${target} with identity field ${identityLabel}`
+            : `Fill the field with identity field ${identityLabel}`;
+        }
+        return hasHighlight
+          ? `Type "${truncated}" into ${target}`
+          : `Type "${truncated}" into the field`;
+      case 'select':
+        if (identityLabel) {
+          return hasHighlight
+            ? `Select identity field ${identityLabel} on ${target}`
+            : `Select identity field ${identityLabel}`;
+        }
+        return hasHighlight
+          ? `Select option "${truncated}" on ${target}`
+          : `Select option "${truncated}"`;
+      case 'scroll': {
+        if (step.mode === 'percent' && Number.isFinite(step.percent)) {
+          return `Scroll page to ${Math.round(step.percent)}%`;
+        }
+        if (step.mode === 'top') return 'Scroll to page top';
+        if (step.mode === 'bottom') return 'Scroll to page bottom';
+        if (hasHighlight) return `Scroll ${target} into view`;
+        if (Number.isFinite(step.offset)) {
+          return `Scroll page by ${Math.round(step.offset)}px`;
+        }
+        return 'Scroll the page';
+      }
+      case 'navigate':
+        return `Navigate to ${truncateForLog(step.url || '', 80)}`;
+      case 'back':
+        return 'Navigate back';
+      case 'forward':
+        return 'Navigate forward';
+      case 'reload':
+        return 'Reload the page';
+      case 'wait': {
+        const ms = Number.isFinite(step.ms) ? step.ms : Number(step.duration) || 0;
+        return `Wait ${Math.max(0, Math.round(ms))} ms`;
+      }
+      case 'status':
+        return `Update status bar: ${truncateForLog(step.message || step.text || '', 80)}`;
+      case 'ip_info':
+        return 'Open IP information panel';
+      case 'ip_check':
+        return 'Run IP qualification check';
+      case 'custom_open': {
+        if (step.siteKey) {
+          return `Open custom web window for "${truncateForLog(step.siteKey, 40)}"`;
+        }
+        if (step.url) {
+          return `Open custom web window to ${truncateForLog(step.url, 80)}`;
+        }
+        return 'Open custom web window';
+      }
+      case 'open_tab':
+        return step.url ? `Open new tab to ${truncateForLog(step.url, 80)}` : 'Open a new tab';
+      case 'note_save':
+        return step.title ? `Save note "${truncateForLog(step.title, 60)}"` : 'Save a new note';
+      case 'dom_scan':
+        return 'Run DOM scan on the current page';
+      case 'ocr_capture':
+        return 'Capture OCR for the selected region';
+      default:
+        return type ? `Execute ${type} step` : 'Execute step';
+    }
+  }
+
+  function describeSurveyAgentPlanStepEnglish(entry) {
+    if (!entry) return '';
+    switch (entry.kind) {
+      case 'dom_scan':
+        return 'Run DOM scan on the current page';
+      case 'ocr_capture': {
+        const reason = entry.reason ? truncateForLog(entry.reason, 60) : '';
+        return reason ? `Capture OCR (${reason})` : 'Capture OCR for the target region';
+      }
+      case 'done':
+        return 'Mark task as complete';
+      case 'action':
+        return formatSurveyAgentActionEnglish(entry.step);
+      default:
+        return 'Execute next step';
+    }
+  }
+
+  function describeSurveyAgentPlanStepArabic(entry) {
+    if (!entry) return '';
+    switch (entry.kind) {
+      case 'dom_scan':
+        return 'إعادة مسح الصفحة بالـDOM';
+      case 'ocr_capture':
+        return entry.reason ? `تشغيل OCR: ${entry.reason}` : 'تشغيل OCR للنطاق المحدد';
+      case 'done':
+        return 'إنهاء المهمة';
+      case 'action':
+        return formatSurveyAgentAction(entry.step);
+      default:
+        return 'خطوة';
+    }
+  }
+
+  function appendSurveyAgentPlanOutline(plan, steps) {
+    const list = Array.isArray(steps) ? steps : [];
+    if (!list.length) return;
+    const lines = [];
+    list.forEach((entry, idx) => {
+      const description = describeSurveyAgentPlanStepEnglish(entry);
+      if (description) {
+        lines.push(`${idx + 1}. ${description}`);
+      }
+    });
+    if (!lines.length) return;
+    if (plan?.meta?.finishWhen) {
+      lines.push(`Finish when: ${plan.meta.finishWhen}`);
+    }
+    const message = `PLAN:\n${lines.join('\n')}`;
+    appendSurveyAgentChatMessage({ role: 'agent', text: message, meta: 'plan-outline' });
+  }
+
+  function appendSurveyAgentProgressUpdate(index, total, entry) {
+    const stepText = describeSurveyAgentPlanStepArabic(entry);
+    if (!stepText) return;
+    const prefix = `الخطوة ${index}/${total}: `;
+    appendSurveyAgentAgentMessage(`${prefix}${stepText}`, 'progress-update');
+  }
+
+  function formatSurveyAgentResult(result) {
+    if (!result || typeof result !== 'object') return '';
+    const details = result.details || {};
+    if (details.summary) return details.summary;
+    if (details.statusMessage) return details.statusMessage;
+    if (details.title && result.code === 'act_noteSave_ok') {
+      return `تم حفظ الملاحظة «${truncateForLog(details.title)}»`;
+    }
+    if (details.skipped) {
+      if (details.text) return `موجود بالفعل "${truncateForLog(details.text)}"`;
+      if (details.value) return `موجود بالفعل "${truncateForLog(details.value)}"`;
+      return 'الحقل مكتمل بالفعل';
+    }
+    if (details.text) return `القيمة "${truncateForLog(details.text)}"`;
+    if (details.value) return `القيمة "${truncateForLog(details.value)}"`;
+    if (details.percent !== undefined) return `تم التمرير إلى ${details.percent}%`;
+    if (details.position) return `الموضع ${details.position}`;
+    if (details.delta !== undefined) return `تمرير بمقدار ${Math.round(details.delta)}px`;
+    if (details.url) return truncateForLog(details.url);
+    if (details.index !== undefined) return `الخيار رقم ${details.index}`;
+    if (result.code) return result.code;
+    return '';
+  }
+
+  function getSurveyAgentStepSignature(step) {
+    if (!step || typeof step !== 'object') return '';
+    const type = typeof step.type === 'string' ? step.type.toLowerCase() : '';
+    const locator = step.locator || {};
+    const highlight = Number.isInteger(locator.highlightIndex) ? locator.highlightIndex : '';
+    const xpath = locator.xpath || locator.cssSelector || locator.css || '';
+    const framePath = Array.isArray(locator.frameChain)
+      ? locator.frameChain
+          .map((frame) => (frame && frame.xpath) || (Number.isInteger(frame?.index) ? `#${frame.index}` : ''))
+          .filter(Boolean)
+          .join('>')
+      : '';
+    const text = type === 'type' || type === 'select' ? step.text || step.value || '' : '';
+    const url = type === 'navigate' ? step.url || '' : '';
+    return [type, highlight, xpath, framePath, text, url]
+      .map((part) => (part === undefined || part === null ? '' : String(part).trim()))
+      .join('|');
+  }
+
+  function inferQuestionFromLocator(locator = {}) {
+    try {
+      const resolved = resolveSurveyAgentElement(locator);
+      if (resolved && resolved.element) {
+        return getElementLabelText(resolved.element) || extractElementText(resolved.element);
+      }
+    } catch (err) {
+      // ignore resolution errors
+    }
+    return '';
+  }
+
+  function buildSurveyAgentHistoryRecord(session, status) {
+    if (!session || typeof session !== 'object') return null;
+    const answers = [];
+    for (const entry of Array.isArray(session.history) ? session.history : []) {
+      const step = entry?.step || entry?.action || {};
+      const result = entry?.result || entry || {};
+      const type = String(step.type || '').toLowerCase();
+      if (type !== 'type' && type !== 'select') continue;
+      const locator = step.locator || {};
+      const details = result.details || {};
+      const answerText = type === 'select'
+        ? details.text || details.value || step.text || ''
+        : details.text || step.text || '';
+      if (!answerText) continue;
+      const question = details.question || inferQuestionFromLocator(locator);
+      answers.push({
+        type,
+        highlightIndex: Number.isInteger(locator.highlightIndex) ? locator.highlightIndex : null,
+        identityKey: details.identityKey || null,
+        question: question || '',
+        answer: answerText,
+      });
+    }
+    if (!answers.length) return null;
+
+    const logs = (session.logs || []).map((entry) => ({
+      level: entry.level,
+      label: entry.label,
+      message: entry.message,
+      detail: entry.detail,
+      timestamp: entry.timestamp,
+    }));
+    const chat = (session.chat || [])
+      .filter((entry) => entry && typeof entry.text === 'string' && entry.text.trim())
+      .map((entry) => ({
+        role: entry.role === 'agent' || entry.role === 'system' ? entry.role : 'user',
+        text: entry.text.trim(),
+        timestamp: entry.timestamp,
+        meta: entry.meta,
+      }));
+    return {
+      id: `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      url: location.href,
+      title: document.title,
+      startedAt: session.startedAt || Date.now(),
+      completedAt: session.completedAt || Date.now(),
+      status,
+      goal: session.goal || '',
+      instructions: session.instructions || '',
+      answers,
+      logs: logs.slice(-80),
+      chat: chat.slice(-SURVEY_AGENT_MAX_CHAT_MESSAGES),
+    };
+  }
+
+  async function persistSurveyAgentHistory(session, status) {
+    const record = buildSurveyAgentHistoryRecord(session, status);
+    if (!record) return;
+    try {
+      await chrome.runtime.sendMessage({ type: 'SURVEY_AGENT_SAVE_HISTORY', record });
+    } catch (err) {
+      console.warn('Survey agent history save failed', err);
+    }
+  }
+
+  function finalizeSurveyAgentSession(session, status, message) {
+    session.running = false;
+    session.stopRequested = false;
+    session.status = status;
+    session.completedAt = Date.now();
+    session.loopPromise = null;
+    session.currentPhase = null;
+    session.rateLimitBackoffMs = 0;
+    session.repeatPlanCount = 0;
+    session.lastPlanSignature = '';
+    session.lastExecutedSignature = '';
+    session.repeatedSuccessCount = 0;
+    session.statusTone = 'status';
+    if (message) {
+      appendSurveyAgentLog({
+        level: status === 'done' ? 'success' : status === 'error' ? 'error' : 'info',
+        label: 'Agent',
+        message,
+      });
+    } else {
+      updateSurveyAgentUiState();
+    }
+    let summaryMessage;
+    if (message) {
+      summaryMessage = message;
+    } else {
+      switch (status) {
+        case 'done':
+          summaryMessage = 'تم إنهاء المهمة بنجاح.';
+          break;
+        case 'aborted':
+          summaryMessage = 'أوقفت الخطة بطلب منك.';
+          break;
+        case 'error':
+          summaryMessage = 'توقفت لأن فيه خطأ يحتاج تدخل منك.';
+          break;
+        case 'stopped':
+          summaryMessage = 'أوقفت التشغيل وتم حفظ التقدم.';
+          break;
+        default:
+          summaryMessage = 'الوكيل جاهز لتعليمات جديدة.';
+          break;
+      }
+    }
+    const tone = status === 'error' ? 'error' : status === 'aborted' || status === 'stopped' ? 'warning' : 'status';
+    setSurveyAgentStatusMessage(summaryMessage, tone);
+    if (summaryMessage) {
+      appendSurveyAgentAgentMessage(summaryMessage, 'summary');
+    }
+    invalidateSurveyAgentDomCache();
+    if (status === 'done') {
+      const payload = {
+        history: Array.isArray(session.history) ? [...session.history] : [],
+        logs: Array.isArray(session.logs) ? [...session.logs] : [],
+        goal: session.goal,
+        instructions: session.instructions,
+        startedAt: session.startedAt,
+        completedAt: session.completedAt,
+        chat: Array.isArray(session.chat) ? [...session.chat] : [],
+      };
+      persistSurveyAgentHistory(payload, status).catch((err) => console.warn('Survey agent history persist failed', err));
+    }
+  }
+
+  function openSurveyAgentPanel() {
+    ensureSurveyAgentStyles();
+    const ui = getSurveyAgentUiState();
+    if (ui.modal && ui.modal.isConnected && !ui.modal.classList.contains('is-closing')) {
+      updateSurveyAgentUiState();
+      return ui.modal;
+    }
+
+    const session = getSurveyAgentSession();
+    if (!session.goal) session.goal = SURVEY_AGENT_DEFAULT_GOAL;
+
+    const panelHtml = `
+      <div class="nano-agent-window">
+        <header class="nano-agent-header">
+          <div class="nano-brand">
+            <span class="nano-logo">Z</span>
+            <div class="nano-heading">
+              <div class="nano-title">وكيل Zepra</div>
+              <div class="nano-status-line">
+                <span class="nano-status-badge is-idle">جاهز</span>
+                <span class="nano-status-text">في انتظار تعليماتك.</span>
+              </div>
+            </div>
+          </div>
+          <div class="nano-header-actions">
+            <button type="button" class="survey-agent-close" aria-label="إغلاق الوكيل">&times;</button>
+          </div>
+        </header>
+        <section class="nano-thread">
+          <div class="nano-placeholder">اكتب تعليماتك وسيبدأ الوكيل فورًا.</div>
+          <div class="nano-messages"></div>
+        </section>
+        <form class="nano-compose">
+          <textarea class="nano-input" rows="3" placeholder="اكتب ما تريد أن أنفذه…"></textarea>
+          <footer>
+            <span class="nano-hint">Shift+Enter لسطر جديد</span>
+            <button type="submit" class="nano-send" disabled>إرسال</button>
+          </footer>
+        </form>
+      </div>
+    `;
+
+    const panel = createSurveyAgentPanel('وكيل Zepra', panelHtml, () => {
+      const currentUi = getSurveyAgentUiState();
+      if (currentUi.modal === panel) {
+        currentUi.modal = null;
+        currentUi.elements = null;
+      }
+    });
+
+    ui.modal = panel;
+    ui.elements = {
+      statusBadge: panel.querySelector('.nano-status-badge'),
+      statusText: panel.querySelector('.nano-status-text'),
+      chatBody: panel.querySelector('.nano-thread'),
+      chatThread: panel.querySelector('.nano-messages'),
+      chatEmpty: panel.querySelector('.nano-placeholder'),
+      chatInput: panel.querySelector('.nano-input'),
+      chatSend: panel.querySelector('.nano-send'),
+      chatForm: panel.querySelector('.nano-compose'),
+    };
+
+    syncSurveyAgentSettingsToUi();
+
+    if (ui.elements.chatForm) {
+      ui.elements.chatForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        handleSurveyAgentChatSubmit();
+      });
+    }
+
+    if (ui.elements.chatSend) {
+      ui.elements.chatSend.addEventListener('click', (event) => {
+        event.preventDefault();
+        handleSurveyAgentChatSubmit();
+      });
+    }
+
+    if (ui.elements.chatInput) {
+      ui.elements.chatInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && !event.shiftKey && !event.altKey) {
+          event.preventDefault();
+          handleSurveyAgentChatSubmit();
+        }
+      });
+      ui.elements.chatInput.addEventListener('input', () => {
+        if (ui.elements.chatSend) {
+          ui.elements.chatSend.disabled = !ui.elements.chatInput.value.trim();
+        }
+      });
+    }
+
+    ensureSurveyAgentChatGreeting();
+    if (ui.elements.chatSend) {
+      ui.elements.chatSend.disabled = !ui.elements.chatInput || !ui.elements.chatInput.value.trim();
+    }
+
+    if (ui.elements.chatInput) {
+      setTimeout(() => {
+        try {
+          ui.elements.chatInput.focus();
+        } catch (err) {
+          // ignore focus errors
+        }
+      }, 60);
+    }
+
+    updateSurveyAgentUiState();
+    return panel;
+  }
+
+  function startSurveyAgentRun(options = {}) {
+    const session = getSurveyAgentSession();
+    if (session.running) {
+      showNotification('الوكيل شغال بالفعل حالياً');
+      return;
+    }
+    session.history = [];
+    session.planCount = 0;
+    session.errorCount = 0;
+    session.logs = [];
+    session.startedAt = Date.now();
+    session.completedAt = 0;
+    session.stopRequested = false;
+    session.status = 'running';
+    const runSettings = getSurveyAgentSettings();
+    session.useIdentityAnswers = runSettings.useIdentityAnswers !== false;
+    session.deliberateMode = Boolean(runSettings.deliberateMode);
+    session.goal = SURVEY_AGENT_DEFAULT_GOAL;
+    session.rateLimitBackoffMs = 0;
+    session.currentPhase = null;
+    session.lastPlanSignature = '';
+    session.repeatPlanCount = 0;
+    session.lastExecutedSignature = '';
+    session.repeatedSuccessCount = 0;
+    session.lastPlanAt = 0;
+    session.lastActionAt = 0;
+    invalidateSurveyAgentDomCache();
+    if (typeof options.instructions === 'string') {
+      session.instructions = options.instructions;
+    }
+    if (session.instructions) {
+      session.goal = session.instructions;
+    }
+    appendSurveyAgentLog({ level: 'info', label: 'Agent', message: 'بدء تشغيل جديد' });
+    const introParts = [];
+    if (session.instructions) {
+      introParts.push(`جارٍ تنفيذ تعليماتك: «${session.instructions}».`);
+    } else {
+      introParts.push('جارٍ تجهيز الخطة لمسح الصفحة.');
+    }
+    if (session.useIdentityAnswers) {
+      introParts.push('سأستخدم بيانات الهوية النشطة لأي حقول شخصية.');
+    }
+    if (session.deliberateMode) {
+      introParts.push('وضع التمهل مُفعّل لتفادي التكرار والأخطاء.');
+    }
+    setSurveyAgentStatusMessage(introParts.join(' '), 'status');
+    updateSurveyAgentPhase(session, 'starting', null, 'status');
+    session.running = true;
+    updateSurveyAgentUiState();
+
+    session.loopPromise = runSurveyAgentLoop(session).finally(() => {
+      session.loopPromise = null;
+      updateSurveyAgentUiState();
+    });
+  }
+
+  function stopSurveyAgentRun(reason = 'تم الإيقاف بطلب يدوي') {
+    const session = getSurveyAgentSession();
+    if (!session.running || session.stopRequested) return;
+    session.stopRequested = true;
+    session.status = 'stopping';
+    appendSurveyAgentLog({ level: 'info', label: 'Agent', message: reason });
+    setSurveyAgentStatusMessage('سأوقف التنفيذ بعد الخطوة الحالية.', 'warning');
+  }
+
+  async function runSurveyAgentLoop(session) {
+    try {
+      while (session.running && !session.stopRequested) {
+        if (session.history.length >= session.maxSteps) {
+          finalizeSurveyAgentSession(session, 'aborted', 'وصلت للحد الأقصى للخطوات.');
+          return;
+        }
+
+        session.status = 'scanning';
+        updateSurveyAgentUiState();
+        updateSurveyAgentPhase(session, 'scanning', 'جارٍ مسح الصفحة عن الأسئلة الجديدة…', 'status');
+
+        let domTree;
+        try {
+          domTree = await collectSurveyDomTree({ showHighlights: false });
+        } catch (err) {
+          finalizeSurveyAgentSession(session, 'error', `تعذّر قراءة الصفحة: ${err?.message || err}`);
+          return;
+        }
+
+        if (session.stopRequested) {
+          break;
+        }
+
+        await ensureSurveyAgentPlanSpacing(session);
+
+        session.status = 'planning';
+        updateSurveyAgentUiState();
+        updateSurveyAgentPhase(session, 'planning', 'بفكر في أحسن خطوة جاية…', 'plan');
+
+        let planResponse;
+        try {
+          planResponse = await chrome.runtime.sendMessage({
+            type: 'SURVEY_AGENT_PLAN_NEXT',
+            domTree,
+            history: session.history,
+            goal: session.goal,
+            instructions: session.instructions ? session.instructions : undefined,
+            context: buildSurveyAgentPlanningContext(domTree, session),
+            options: buildSurveyAgentPlannerOptions(session),
+            conversation: buildSurveyAgentPlannerConversation(),
+          });
+        } catch (err) {
+          planResponse = { ok: false, error: err?.message || String(err) };
+        }
+
+        session.lastPlanAt = Date.now();
+
+        if (session.stopRequested) {
+          break;
+        }
+
+        if (!planResponse || !planResponse.ok) {
+          const rawError = planResponse?.error;
+          const errorMessage =
+            typeof rawError === 'string' && rawError.trim()
+              ? rawError.trim()
+              : String(rawError || 'Unknown planner failure');
+          const errorCode = planResponse?.code || '';
+          const normalized = errorMessage.toLowerCase();
+          const isRateLimit =
+            errorCode === 'CEREBRAS_RATE_LIMIT' ||
+            errorCode === 'token_quota_exceeded' ||
+            normalized.includes('too_many_tokens') ||
+            normalized.includes('tokens per minute');
+          if (isRateLimit) {
+            session.rateLimitBackoffMs = session.rateLimitBackoffMs
+              ? Math.min(Math.round(session.rateLimitBackoffMs * 1.6), SURVEY_AGENT_RATE_LIMIT_BACKOFF_MAX)
+              : SURVEY_AGENT_RATE_LIMIT_BACKOFF_INITIAL;
+            const waitSeconds = Math.max(1, Math.ceil(session.rateLimitBackoffMs / 1000));
+            appendSurveyAgentLog({
+              level: 'warn',
+              label: 'Planner',
+              message: 'تم تهدئة السرعة من المزود',
+              detail: errorMessage,
+            });
+            session.status = 'rate-limit';
+            updateSurveyAgentUiState();
+            updateSurveyAgentPhase(
+              session,
+              'rate-limit',
+              `مزود Cerebras موقف الطلبات مؤقتًا، هنستنى ${waitSeconds} ثانية وبعدين نحاول تاني.`,
+              'warning'
+            );
+            await sleep(session.rateLimitBackoffMs);
+            continue;
+          }
+
+        session.errorCount += 1;
+        appendSurveyAgentLog({
+          level: 'error',
+          label: `Plan ${session.planCount + 1}`,
+          message: 'خطأ في التخطيط',
+          detail: errorMessage,
+        });
+        appendSurveyAgentAgentMessage(`معرفتش أخطط للخطوة الجاية: ${errorMessage}. هحاول تاني…`, 'error');
+        if (session.errorCount >= SURVEY_AGENT_MAX_PLAN_ERRORS) {
+          finalizeSurveyAgentSession(session, 'error', 'المخطط فشل أكثر من مرة متتالية.');
+          return;
+        }
+          await sleep(600);
+          continue;
+        }
+
+        session.rateLimitBackoffMs = 0;
+        session.errorCount = 0;
+        session.planCount += 1;
+
+        const plan = planResponse;
+        const planSteps = Array.isArray(plan.steps) && plan.steps.length
+          ? plan.steps.filter(Boolean)
+          : plan.step
+          ? [{ kind: 'action', step: plan.step }]
+          : [];
+        if (plan.meta && Array.isArray(plan.meta.statusUpdates) && plan.meta.statusUpdates.length) {
+          const updates = plan.meta.statusUpdates;
+          const lastUpdate = updates[updates.length - 1];
+          for (const update of updates) {
+            if (update && update.message) {
+              setSurveyAgentStatusMessage(String(update.message), update.tone || 'status');
+            }
+          }
+          if (lastUpdate && lastUpdate.message) {
+            appendSurveyAgentLog({
+              level: 'status',
+              label: 'حالة',
+              message: lastUpdate.message,
+            });
+          }
+        }
+        const firstActionEntry = planSteps.find((entry) => entry && entry.kind === 'action' && entry.step);
+        const primaryStep = firstActionEntry ? firstActionEntry.step : plan.step;
+        const planMessage = formatSurveyAgentAction(primaryStep) || 'لا توجد خطوة قابلة للتنفيذ';
+        const planDetails = [];
+        if (plan.explanation) planDetails.push(plan.explanation.trim());
+        if (typeof plan.confidence === 'number' && !Number.isNaN(plan.confidence)) {
+          planDetails.push(`الثقة ${(plan.confidence * 100).toFixed(0)}%`);
+        }
+        appendSurveyAgentLog({
+          level: 'plan',
+          label: `Plan ${session.planCount}`,
+          message: planMessage,
+          detail: planDetails.join(' • '),
+        });
+
+        appendSurveyAgentPlanOutline(plan, planSteps);
+
+        if (plan.explanation) {
+          const meta = plan.status === 'continue' ? 'plan' : 'status';
+          appendSurveyAgentAgentMessage(plan.explanation.trim(), meta);
+        }
+
+        if (plan.status === 'done') {
+          finalizeSurveyAgentSession(session, 'done', plan.explanation || 'تم إنهاء الاستبيان.');
+          return;
+        }
+        if (plan.status === 'abort') {
+          finalizeSurveyAgentSession(session, 'aborted', plan.explanation || 'المخطط قرر إيقاف التنفيذ.');
+          return;
+        }
+
+        if (!primaryStep) {
+          session.errorCount += 1;
+          appendSurveyAgentLog({
+            level: 'error',
+            label: `Plan ${session.planCount}`,
+            message: 'المخطط لم يرجع خطوة.',
+          });
+          appendSurveyAgentAgentMessage('الخطة مش واضحة، هراجع الصفحة وأحاول تاني.', 'plan');
+          if (session.errorCount >= SURVEY_AGENT_MAX_PLAN_ERRORS) {
+            finalizeSurveyAgentSession(session, 'error', 'المخطط أعاد خطوات فارغة أكثر من مرة.');
+            return;
+          }
+          await sleep(400);
+          continue;
+        }
+
+        const signature = getSurveyAgentStepSignature(primaryStep);
+        if (signature) {
+          if (session.lastPlanSignature === signature) {
+            session.repeatPlanCount = (session.repeatPlanCount || 0) + 1;
+          } else {
+            session.repeatPlanCount = 0;
+          }
+          session.lastPlanSignature = signature;
+        } else {
+          session.lastPlanSignature = '';
+          session.repeatPlanCount = 0;
+        }
+
+        if (session.repeatPlanCount >= SURVEY_AGENT_PLAN_REPEAT_LIMIT) {
+          appendSurveyAgentLog({
+            level: 'warning',
+            label: 'Loop guard',
+            message: 'المخطط كرر نفس الخطوة',
+            detail: planMessage,
+          });
+          session.status = 'loop-guard';
+          updateSurveyAgentUiState();
+          updateSurveyAgentPhase(
+            session,
+            'loop-guard',
+            'المخطط كرر نفس الخطوة بدون تقدم.',
+            'warning'
+          );
+          appendSurveyAgentAgentMessage('الخطوة مكررة ومفيش تقدم. ممكن تدلّني أعمل إيه بعد كده؟', 'ask');
+          session.history.push({
+            step: primaryStep ? { ...primaryStep } : undefined,
+            result: {
+              ok: false,
+              status: 'fail',
+              code: 'act_errors_repeat_plan',
+              error: 'PLAN_REPEATED_WITHOUT_PROGRESS',
+              details: { locator: primaryStep?.locator || {}, reason: 'repeat_plan_limit' },
+            },
+          });
+          if (session.history.length > SURVEY_AGENT_HISTORY_LIMIT) {
+            session.history = session.history.slice(-SURVEY_AGENT_HISTORY_LIMIT);
+          }
+          session.repeatPlanCount = 0;
+          await sleep(700);
+          continue;
+        }
+
+        const lastHistoryEntry = session.history[session.history.length - 1];
+        const lastSignature = lastHistoryEntry ? getSurveyAgentStepSignature(lastHistoryEntry.step) : '';
+        if (signature && lastSignature && signature === lastSignature && lastHistoryEntry?.result?.ok) {
+          session.repeatedSuccessCount = (session.repeatedSuccessCount || 0) + 1;
+        } else {
+          session.repeatedSuccessCount = 0;
+        }
+
+        if (session.repeatedSuccessCount >= SURVEY_AGENT_REPEAT_STUCK_LIMIT) {
+          appendSurveyAgentLog({
+            level: 'warning',
+            label: 'Loop guard',
+            message: 'الخطوة تكررت بدون تقدم',
+            detail: planMessage,
+          });
+          session.status = 'loop-guard';
+          updateSurveyAgentUiState();
+          updateSurveyAgentPhase(
+            session,
+            'loop-guard',
+            'نفذت الخطوة لكن الصفحة ما اتغيرتش.',
+            'warning'
+          );
+          appendSurveyAgentAgentMessage('الصفحة ما اتغيرتش بعد الخطوة، ممكن تتأكد أو ترشدني؟', 'ask');
+          session.history.push({
+            step: primaryStep ? { ...primaryStep } : undefined,
+            result: {
+              ok: false,
+              status: 'fail',
+              code: 'act_errors_no_progress',
+              error: 'NO_PROGRESS_AFTER_REPEAT',
+              details: { locator: primaryStep?.locator || {}, reason: 'repeat_no_progress' },
+            },
+          });
+          if (session.history.length > SURVEY_AGENT_HISTORY_LIMIT) {
+            session.history = session.history.slice(-SURVEY_AGENT_HISTORY_LIMIT);
+          }
+          session.repeatedSuccessCount = 0;
+          await sleep(600);
+          continue;
+        }
+
+        const stepsToExecute = planSteps.length ? planSteps : [{ kind: 'action', step: primaryStep }];
+        let executionFailed = false;
+
+        for (let idx = 0; idx < stepsToExecute.length; idx += 1) {
+          if (!session.running || session.stopRequested) break;
+          const entry = stepsToExecute[idx];
+          if (!entry) continue;
+
+          appendSurveyAgentProgressUpdate(idx + 1, stepsToExecute.length, entry);
+
+          if (entry.kind === 'dom_scan') {
+            session.status = 'scanning';
+            updateSurveyAgentUiState();
+            updateSurveyAgentPhase(session, 'scanning', 'جارٍ مسح الصفحة عن الأسئلة الجديدة…', 'status');
+            try {
+              const tree = await collectSurveyDomTree({ forceRefresh: true });
+              const nodeCount = tree?.map ? Object.keys(tree.map).length : 0;
+              appendSurveyAgentLog({
+                level: 'info',
+                label: 'dom.scan',
+                message: 'مسح هيكل الصفحة',
+                detail: nodeCount ? `العناصر ${nodeCount}` : undefined,
+              });
+            } catch (err) {
+              const errorText = err?.message || String(err);
+              appendSurveyAgentLog({ level: 'error', label: 'dom.scan', message: 'فشل مسح الصفحة', detail: errorText });
+              appendSurveyAgentAgentMessage(`خطأ أثناء مسح الصفحة: ${errorText}.`, 'error');
+              executionFailed = true;
+              break;
+            }
+            continue;
+          }
+
+          if (entry.kind === 'ocr_capture') {
+            session.status = 'executing';
+            updateSurveyAgentUiState();
+            updateSurveyAgentPhase(session, 'executing', 'تشغيل OCR للعنصر المحدد…', 'status');
+            const ocrResult = await executeSurveyAgentOcrCapture(entry);
+            appendSurveyAgentLog({
+              level: ocrResult.ok ? 'info' : 'error',
+              label: 'OCR',
+              message: ocrResult.ok ? 'تم استخراج النص من الصورة' : 'فشل تنفيذ OCR',
+              detail: ocrResult.ok ? truncateForLog(ocrResult.details?.text || '', 120) : (ocrResult.error || ocrResult.code),
+            });
+            if (!ocrResult.ok) {
+              appendSurveyAgentAgentMessage(`تعذّر تشغيل OCR: ${ocrResult.error || ocrResult.code}.`, 'error');
+              executionFailed = true;
+              break;
+            }
+            if (ocrResult.details?.text) {
+              appendSurveyAgentAgentMessage('تم استخراج النص من الصورة بنجاح.', 'summary');
+            }
+            continue;
+          }
+
+          if (entry.kind === 'done') {
+            finalizeSurveyAgentSession(session, 'done', plan.explanation || 'تم إنهاء المهمة.');
+            return;
+          }
+
+          const stepToRun = entry.step || null;
+          if (!stepToRun) {
+            continue;
+          }
+
+          session.status = 'executing';
+          updateSurveyAgentUiState();
+          const planMessageCurrent = formatSurveyAgentAction(stepToRun) || 'خطوة';
+          updateSurveyAgentPhase(session, 'executing', `تنفيذ الخطوة: ${planMessageCurrent}`, 'status');
+
+          let actionResult;
+          if ((stepToRun.type || '').toLowerCase() === 'wait') {
+            const waitMs = Number.isFinite(stepToRun.ms)
+              ? Math.max(0, stepToRun.ms)
+              : Math.max(0, Number(stepToRun.duration) || 0);
+            appendSurveyAgentLog({ level: 'info', label: 'انتظار', message: `انتظار ${Math.round(waitMs)} مللي ثانية` });
+            await sleep(waitMs);
+            actionResult = { ok: true, code: 'act_wait_ok', details: { ms: waitMs }, status: 'ok' };
+          } else {
+            try {
+              actionResult = await executeSurveyAgentAction(stepToRun);
+            } catch (err) {
+              actionResult = { ok: false, error: err?.message || String(err), code: err?.code };
+            }
+          }
+
+          const normalizedResult = {
+            ok: Boolean(actionResult?.ok),
+            code: actionResult?.code || (actionResult?.ok ? 'act_unknown_ok' : 'act_unknown_fail'),
+            details: actionResult?.details || {},
+            error: actionResult?.error,
+            status: actionResult?.status || (actionResult?.ok === false ? 'fail' : 'ok'),
+          };
+
+          const executedStep = { ...stepToRun };
+          if (normalizedResult.details && typeof normalizedResult.details.text === 'string') {
+            if (executedStep.type === 'type' || executedStep.type === 'select') {
+              executedStep.text = normalizedResult.details.text;
+            }
+          }
+
+          session.history.push({ step: executedStep, result: normalizedResult });
+          if (session.history.length > SURVEY_AGENT_HISTORY_LIMIT) {
+            session.history = session.history.slice(-SURVEY_AGENT_HISTORY_LIMIT);
+          }
+
+          session.lastExecutedSignature = getSurveyAgentStepSignature(executedStep) || '';
+          if (normalizedResult.ok) {
+            session.repeatedSuccessCount = 0;
+          }
+
+          appendSurveyAgentLog({
+            level: normalizedResult.ok ? 'success' : 'error',
+            label: normalizedResult.ok ? 'الخطوة' : 'فشل الخطوة',
+            message: planMessageCurrent,
+            detail: normalizedResult.ok ? formatSurveyAgentResult(normalizedResult) : (normalizedResult.error || normalizedResult.code),
+          });
+
+          if (!normalizedResult.ok) {
+            const failureDetail = normalizedResult.error || normalizedResult.code || 'فشل الخطوة';
+            appendSurveyAgentAgentMessage(`الخطوة فشلت: ${failureDetail}. هعدّل وحاول تاني.`, 'error');
+            session.lastActionAt = Date.now();
+            executionFailed = true;
+            break;
+          }
+
+          const stepType = (executedStep.type || '').toLowerCase();
+          if (
+            stepType &&
+            !['wait', 'status', 'ip_info', 'ip_check', 'custom_open', 'note_save', 'open_tab', 'ocr_capture', 'dom_scan'].includes(stepType)
+          ) {
+            invalidateSurveyAgentDomCache();
+          }
+
+          session.lastActionAt = Date.now();
+          const baseDelay = normalizedResult.ok ? SURVEY_AGENT_POST_ACTION_DELAY_OK : SURVEY_AGENT_POST_ACTION_DELAY_FAIL;
+          const deliberateDelay = session.deliberateMode ? SURVEY_AGENT_POST_ACTION_DELAY_DELIBERATE : 0;
+          await sleep(baseDelay + deliberateDelay);
+        }
+
+        if (executionFailed) {
+          session.status = 'review';
+          updateSurveyAgentUiState();
+          updateSurveyAgentPhase(session, 'review', 'براجع الصفحة قبل التخطيط للخطوة الجاية.', 'status');
+          continue;
+        }
+
+        session.status = 'review';
+        updateSurveyAgentUiState();
+        updateSurveyAgentPhase(session, 'review', 'براجع الصفحة قبل التخطيط للخطوة الجاية.', 'status');
+      }
+
+      if (session.stopRequested) {
+        finalizeSurveyAgentSession(session, 'stopped', 'تم الإيقاف بناءً على طلبك.');
+      } else if (session.running) {
+        finalizeSurveyAgentSession(session, 'done');
+      }
+    } catch (err) {
+      finalizeSurveyAgentSession(session, 'error', `خطأ في الوكيل: ${err?.message || err}`);
+    }
+  }
+
+  function evaluateXPathInDocument(xpath, doc) {
+    if (!xpath || !doc) return null;
+    const trimmed = String(xpath).trim();
+    if (!trimmed) return null;
+    const attempts = [];
+    if (trimmed.startsWith('/') || trimmed.startsWith('.')) {
+      attempts.push(trimmed);
+    } else {
+      attempts.push(`//${trimmed}`);
+      attempts.push(`/${trimmed}`);
+    }
+    for (const attempt of attempts) {
+      try {
+        const result = doc.evaluate(attempt, doc, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+        if (result && result.singleNodeValue) {
+          return result.singleNodeValue;
+        }
+      } catch (e) {
+        // ignore evaluation errors
+      }
+    }
+    return null;
+  }
+
+  function resolveSurveyAgentElement(locator = {}) {
+    const resolved = {
+      element: null,
+      frameElements: [],
+      frameChain: [],
+      highlightEntry: null,
+      reason: null,
+      doc: document,
+    };
+
+    const highlightIndex = Number.isInteger(locator.highlightIndex) ? locator.highlightIndex : null;
+    const state = STATE.surveyAgent;
+    let highlightEntry = null;
+    if (highlightIndex !== null && state.highlightLookup instanceof Map) {
+      highlightEntry = state.highlightLookup.get(highlightIndex) || null;
+    }
+    if (!highlightEntry && locator.nodeId && state.nodeById instanceof Map) {
+      const node = state.nodeById.get(String(locator.nodeId));
+      if (node && Number.isInteger(node.highlightIndex)) {
+        highlightEntry = state.highlightLookup.get(node.highlightIndex) || null;
+      }
+    }
+
+    const frameChain = Array.isArray(locator.frameChain)
+      ? locator.frameChain
+      : highlightEntry?.frameChain || [];
+
+    let doc = document;
+    const frameElements = [];
+    for (const frame of frameChain) {
+      const frameXPath = frame?.xpath || frame?.frameXPath || '';
+      const frameCss = frame?.css || '';
+      const frameElement =
+        (frameXPath ? evaluateXPathInDocument(frameXPath, doc) : null) ||
+        (frameCss ? doc.querySelector(frameCss) : null);
+      if (!frameElement) {
+        resolved.reason = 'IFRAME_NOT_FOUND';
+        return resolved;
+      }
+      if (!(frameElement instanceof HTMLIFrameElement)) {
+        resolved.reason = 'FRAME_NOT_IFRAME';
+        return resolved;
+      }
+      const frameDoc = frameElement.contentDocument;
+      if (!frameDoc) {
+        resolved.reason = 'CROSS_ORIGIN_IFRAME';
+        return resolved;
+      }
+      frameElements.push(frameElement);
+      doc = frameDoc;
+    }
+
+    const targetXPath = locator.xpath || highlightEntry?.xpath || '';
+    let element = targetXPath ? evaluateXPathInDocument(targetXPath, doc) : null;
+    if (!element && locator.css) {
+      element = doc.querySelector(locator.css);
+    }
+    if (!element && locator.text) {
+      const normalized = String(locator.text).trim().toLowerCase();
+      if (normalized) {
+        const candidates = Array.from(
+          doc.querySelectorAll(
+            'button, a, input, textarea, select, label, [role="button"], [role="option"], [role="menuitem"], [data-action]'
+          )
+        );
+        element = candidates.find((node) => (node.textContent || node.value || '').trim().toLowerCase() === normalized) || null;
+      }
+    }
+
+    resolved.element = element || null;
+    resolved.frameElements = frameElements;
+    resolved.frameChain = frameChain;
+    resolved.highlightEntry = highlightEntry;
+    resolved.doc = doc;
+
+    if (!resolved.element) {
+      resolved.reason = resolved.reason || 'ELEMENT_NOT_FOUND';
+    }
+
+    return resolved;
+  }
+
+  function focusFrameElements(frameElements) {
+    if (!Array.isArray(frameElements) || frameElements.length === 0) return;
+    const lastFrame = frameElements[frameElements.length - 1];
+    try {
+      lastFrame?.focus?.();
+    } catch (e) {
+      // ignore focus errors
+    }
+  }
+
+  function ensureElementInView(element, behavior = 'instant') {
+    if (!element) return;
+    try {
+      element.scrollIntoView({ block: 'center', inline: 'center', behavior });
+    } catch (e) {
+      try {
+        element.scrollIntoView();
+      } catch (err) {
+        // ignore scroll errors
+      }
+    }
+  }
+
+  function simulateElementClick(element, options = {}) {
+    if (!element) throw new Error('ELEMENT_UNDEFINED');
+    const doc = element.ownerDocument || document;
+    const win = doc.defaultView || window;
+    if (options.scrollIntoView !== false) {
+      ensureElementInView(element, options.scrollBehavior === 'smooth' ? 'smooth' : 'instant');
+    }
+    if (typeof element.focus === 'function') {
+      try {
+        element.focus({ preventScroll: options.scrollIntoView === false });
+      } catch (e) {
+        element.focus();
+      }
+    }
+    const rect = element.getBoundingClientRect();
+    const clientX = rect.left + Math.max(1, rect.width / 2);
+    const clientY = rect.top + Math.max(1, rect.height / 2);
+    const eventInit = {
+      bubbles: true,
+      cancelable: true,
+      view: win,
+      clientX,
+      clientY,
+      screenX: (win?.screenX || 0) + clientX,
+      screenY: (win?.screenY || 0) + clientY,
+      button: 0,
+    };
+    const PointerCtor = win.PointerEvent || win.MouseEvent || MouseEvent;
+    const MouseCtor = win.MouseEvent || MouseEvent;
+    const sequence = [
+      ['pointerover', PointerCtor],
+      ['mouseover', MouseCtor],
+      ['pointerdown', PointerCtor],
+      ['mousedown', MouseCtor],
+      ['pointerup', PointerCtor],
+      ['mouseup', MouseCtor],
+      ['click', MouseCtor],
+    ];
+    for (const [type, Ctor] of sequence) {
+      try {
+        const event = new Ctor(type, eventInit);
+        element.dispatchEvent(event);
+      } catch (e) {
+        // ignore dispatch failures
+      }
+    }
+  }
+
+  function extractElementText(element) {
+    if (!element) return '';
+    if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA') {
+      return (element.value || element.placeholder || '').trim();
+    }
+    return (element.innerText || element.textContent || '').trim().replace(/\s+/g, ' ');
+  }
+
+  async function typeValueIntoElement(element, text, options = {}) {
+    if (!element) throw new Error('ELEMENT_UNDEFINED');
+    const speed = options.typingSpeed || options.speed || 'normal';
+    const delays = speed === 'fast' ? [5, 15] : speed === 'slow' ? [60, 120] : [25, 60];
+    const isInput = (node) => node && (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA');
+    const isContentEditable = (node) => node && node.isContentEditable;
+    const dispatch = (node, type) => node && node.dispatchEvent(new Event(type, { bubbles: true }));
+    const setter = isInput(element)
+      ? (value) => {
+          const proto = element.tagName === 'INPUT' ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+          const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+          if (desc && desc.set) desc.set.call(element, value);
+          else element.value = value;
+        }
+      : isContentEditable(element)
+      ? (value) => {
+          element.innerHTML = '';
+          element.textContent = value;
+        }
+      : (value) => {
+          element.textContent = value;
+        };
+    const getter = isInput(element)
+      ? () => element.value
+      : () => element.value ?? element.textContent ?? '';
+
+    if (typeof element.focus === 'function') {
+      try {
+        element.focus({ preventScroll: true });
+      } catch (e) {
+        element.focus();
+      }
+    }
+
+    if (options.replace !== false) {
+      const currentValue = getter();
+      if (currentValue) {
+        setter('');
+        dispatch(element, 'input');
+      }
+    }
+
+    const valueToType = text == null ? '' : String(text);
+    if (!valueToType) {
+      dispatch(element, 'change');
+      return;
+    }
+
+    let current = getter() || '';
+    for (const ch of valueToType) {
+      dispatch(element, 'keydown');
+      setter(current + ch);
+      current += ch;
+      dispatch(element, 'input');
+      dispatch(element, 'keyup');
+      await sleep(rand(delays[0], delays[1]));
+    }
+    dispatch(element, 'change');
+  }
+
+  function selectOptionOnElement(element, text) {
+    if (!element || element.tagName !== 'SELECT') {
+      throw new Error('NOT_SELECT_ELEMENT');
+    }
+    const options = Array.from(element.options || []);
+    if (!options.length) {
+      return { selected: false };
+    }
+    const normalized = String(text || '').trim().toLowerCase();
+    let match = options.find((opt) => opt.textContent?.trim().toLowerCase() === normalized);
+    if (!match) {
+      match = options.find((opt) => opt.value?.trim().toLowerCase() === normalized);
+    }
+    if (!match && normalized) {
+      match = options.find((opt) => opt.textContent?.trim().toLowerCase().includes(normalized));
+    }
+    if (!match && normalized) {
+      match = options.find((opt) => normalized.includes(opt.textContent?.trim().toLowerCase() || ''));
+    }
+    if (!match) {
+      return { selected: false };
+    }
+    element.value = match.value;
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return {
+      selected: true,
+      value: match.value,
+      text: match.textContent?.trim() || match.value,
+    };
+  }
+
+  function normalizeSurveyAgentValue(value) {
+    if (typeof value !== 'string') return '';
+    return value.replace(/\s+/g, ' ').trim();
+  }
+
+  function getElementCurrentValueSnapshot(element) {
+    if (!element) return '';
+    const tag = element.tagName;
+    if (tag === 'SELECT') {
+      const selected = Array.from(element.selectedOptions || []);
+      if (!selected.length) return '';
+      return selected
+        .map((opt) => (opt.textContent || opt.value || '').trim())
+        .filter(Boolean)
+        .join(', ');
+    }
+    if (tag === 'INPUT') {
+      const type = (element.type || '').toLowerCase();
+      if (type === 'checkbox' || type === 'radio') {
+        return element.checked ? 'checked' : '';
+      }
+      return (element.value || '').trim();
+    }
+    if (tag === 'TEXTAREA') {
+      return (element.value || element.textContent || '').trim();
+    }
+    if (element.isContentEditable) {
+      return (element.textContent || '').trim();
+    }
+    return '';
+  }
+
+  function getSelectSelectionInfo(element) {
+    if (!element || element.tagName !== 'SELECT') return { text: '', value: '' };
+    const selected = Array.from(element.selectedOptions || []);
+    if (!selected.length) return { text: '', value: '' };
+    const primary = selected[0];
+    return {
+      text: (primary.textContent || '').trim(),
+      value: (primary.value || '').trim(),
+    };
+  }
+
+  function isSelectValueAlreadyChosen(element, desiredText) {
+    if (!element || element.tagName !== 'SELECT') return false;
+    const normalizedDesired = normalizeSurveyAgentValue(desiredText || '');
+    const selected = Array.from(element.selectedOptions || []);
+    if (!selected.length) return !normalizedDesired;
+    return selected.some((opt) => {
+      const text = normalizeSurveyAgentValue(opt.textContent || '');
+      const value = normalizeSurveyAgentValue(opt.value || '');
+      return text === normalizedDesired || value === normalizedDesired;
+    });
+  }
+
+  function performScrollAction(action = {}, resolved) {
+    const mode = action.mode || 'element';
+    const targetDoc = resolved?.doc || document;
+    const targetWin = targetDoc.defaultView || window;
+    const behavior = action.behavior === 'smooth' ? 'smooth' : 'instant';
+
+    if (mode === 'element') {
+      if (resolved && resolved.element) {
+        ensureElementInView(resolved.element, behavior);
+        return { target: extractElementText(resolved.element) };
+      }
+      const viewport = targetWin || window;
+      const defaultStep = viewport.innerHeight ? Math.round(viewport.innerHeight * 0.7) : 480;
+      const fallbackDelta = Number.isFinite(action.offset) ? action.offset : defaultStep;
+      try {
+        viewport.scrollBy({ top: fallbackDelta, behavior });
+      } catch (err) {
+        viewport.scrollBy(0, fallbackDelta);
+      }
+      return { fallback: true, delta: fallbackDelta };
+    }
+
+    if (mode === 'percent') {
+      const percent = Number(action.percent);
+      if (!Number.isFinite(percent)) {
+        throw new Error('INVALID_PERCENT');
+      }
+      const docEl = targetDoc.documentElement || targetDoc.body;
+      const totalHeight = (docEl?.scrollHeight || 0) - (targetWin.innerHeight || 0);
+      const clampedPercent = Math.max(0, Math.min(100, percent));
+      const y = totalHeight <= 0 ? 0 : Math.round((clampedPercent / 100) * totalHeight);
+      targetWin.scrollTo({ top: y, behavior });
+      return { percent: clampedPercent };
+    }
+
+    if (mode === 'top') {
+      targetWin.scrollTo({ top: 0, behavior });
+      return { position: 'top' };
+    }
+
+    if (mode === 'bottom') {
+      const docEl = targetDoc.documentElement || targetDoc.body;
+      const totalHeight = (docEl?.scrollHeight || 0) - (targetWin.innerHeight || 0);
+      targetWin.scrollTo({ top: Math.max(0, totalHeight), behavior });
+      return { position: 'bottom' };
+    }
+
+    throw new Error('UNKNOWN_SCROLL_MODE');
+  }
+
+  function getElementLabelText(element) {
+    if (!element) return '';
+    const doc = element.ownerDocument || document;
+    let label = '';
+    if (element.labels && element.labels.length) {
+      label = Array.from(element.labels)
+        .map((el) => (el?.textContent || '').trim())
+        .filter(Boolean)
+        .join(' ');
+    }
+    if (!label && element.id) {
+      try {
+        const selector = `label[for="${typeof CSS !== 'undefined' ? CSS.escape(element.id) : element.id}"]`;
+        const forLabel = doc.querySelector(selector);
+        if (forLabel) label = forLabel.textContent || '';
+      } catch (err) {
+        // ignore invalid selector
+      }
+    }
+    if (!label) {
+      const direct = element.closest?.('label');
+      if (direct) label = direct.textContent || '';
+    }
+    if (!label && element.getAttribute) {
+      label = element.getAttribute('aria-label') || '';
+      if (!label) {
+        const labelledBy = element.getAttribute('aria-labelledby');
+        if (labelledBy) {
+          label = labelledBy
+            .split(/\s+/)
+            .map((id) => (doc.getElementById(id)?.textContent || '').trim())
+            .filter(Boolean)
+            .join(' ');
+        }
+      }
+      if (!label) {
+        label = element.getAttribute('placeholder') || '';
+      }
+    }
+    return (label || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function resolveSurveyAgentInputValue(action = {}, element) {
+    const valueInfo = {
+      text: typeof action.text === 'string' ? action.text : '',
+      identityKey: null,
+      usedIdentity: false,
+      missingIdentity: false,
+    };
+    let requestedKey = null;
+    if (typeof action.intent === 'string') {
+      const match = action.intent.match(/identity[:.]([\w-]+)/i);
+      if (match) requestedKey = match[1];
+    }
+    if (!requestedKey && typeof action.text === 'string') {
+      const placeholder = action.text.match(/{{\s*identity[:.]?([\w-]+)\s*}}/i);
+      if (placeholder) {
+        requestedKey = placeholder[1];
+        valueInfo.text = '';
+      }
+    }
+    if (!requestedKey && element) {
+      const inferred = detectField(element);
+      if (inferred) requestedKey = inferred;
+    }
+    if (requestedKey) {
+      valueInfo.identityKey = requestedKey;
+      const allowIdentity = getSurveyAgentSettings().useIdentityAnswers !== false;
+      const identityValue = allowIdentity && activeIdentity && activeIdentity[requestedKey];
+      if (allowIdentity && typeof identityValue === 'string' && identityValue.trim()) {
+        valueInfo.text = identityValue.trim();
+        valueInfo.usedIdentity = true;
+      } else if (!allowIdentity) {
+        if (!valueInfo.text || /{{\s*identity/i.test(valueInfo.text)) {
+          valueInfo.missingIdentity = true;
+        }
+      } else if (valueInfo.text === '' || /{{\s*identity/i.test(valueInfo.text)) {
+        valueInfo.missingIdentity = true;
+      }
+    }
+    return valueInfo;
+  }
+
+  async function executeSurveyAgentOcrCapture(step = {}) {
+    try {
+      const rect = Array.isArray(step.rect) ? step.rect : null;
+      const stored = await chrome.storage.local.get('ocrLang');
+      const langValue = stored && typeof stored.ocrLang === 'string' ? stored.ocrLang.trim() : '';
+      const lang = langValue || 'eng';
+      const response = await chrome.runtime.sendMessage({
+        type: 'CAPTURE_AND_OCR',
+        rect,
+        tabId: await getTabId(),
+        ocrLang: lang,
+      });
+      if (response?.ok) {
+        return {
+          ok: true,
+          code: 'act_ocrCapture_ok',
+          status: 'ok',
+          details: { text: response.text || '', rect },
+        };
+      }
+      return {
+        ok: false,
+        code: 'act_ocrCapture_fail',
+        status: 'fail',
+        error: response?.error || 'OCR_FAILED',
+        details: { rect },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        code: 'act_ocrCapture_fail',
+        status: 'fail',
+        error: err?.message || String(err),
+        details: { rect: Array.isArray(step.rect) ? step.rect : null },
+      };
+    }
+  }
+
+  async function executeSurveyAgentAction(action = {}) {
+    if (!action || typeof action !== 'object') {
+      return { ok: false, error: 'INVALID_ACTION', code: 'act_errors_invalidAction' };
+    }
+
+    const rawType = action.type || action.name;
+    const type = typeof rawType === 'string' ? rawType.toLowerCase() : '';
+    const locator = action.locator || {};
+
+    const needsElement = type === 'click' || type === 'type' || type === 'select';
+    const usesLocator = needsElement || (type === 'scroll' && (!action.mode || action.mode === 'element'));
+
+    let resolved = {
+      element: null,
+      doc: document,
+      frameElements: [],
+      frameChain: [],
+      reason: null,
+    };
+
+    if (usesLocator) {
+      if (type === 'scroll' && action.mode && action.mode !== 'element') {
+        resolved = { element: null, doc: document, frameElements: [], frameChain: [], reason: null };
+      } else {
+        resolved = resolveSurveyAgentElement(locator) || {
+          element: null,
+          doc: document,
+          frameElements: [],
+          frameChain: [],
+          reason: 'ELEMENT_NOT_FOUND',
+        };
+        if (needsElement && !resolved.element) {
+          return {
+            ok: false,
+            error: resolved.reason || 'ELEMENT_NOT_FOUND',
+            code: action.intent || 'act_errors_elementNotExist',
+            details: { locator },
+          };
+        }
+      }
+    } else if (type === 'scroll') {
+      resolved = { element: null, doc: document, frameElements: [], frameChain: [], reason: null };
+    }
+
+    try {
+      switch (type) {
+        case 'click': {
+          focusFrameElements(resolved.frameElements);
+          simulateElementClick(resolved.element, {
+            scrollIntoView: action.scrollIntoView !== false,
+            scrollBehavior: action.scrollBehavior,
+          });
+          const text = extractElementText(resolved.element);
+          return {
+            ok: true,
+            code: 'act_click_ok',
+            details: {
+              index: locator.highlightIndex,
+              text,
+            },
+          };
+        }
+        case 'type': {
+          focusFrameElements(resolved.frameElements);
+          const valueInfo = resolveSurveyAgentInputValue(action, resolved.element);
+          if (valueInfo.missingIdentity) {
+            return {
+              ok: false,
+              error: 'IDENTITY_VALUE_MISSING',
+              code: 'act_identity_missing',
+              details: { key: valueInfo.identityKey, index: locator.highlightIndex },
+            };
+          }
+          const desiredText = valueInfo.text || '';
+          const currentSnapshot = normalizeSurveyAgentValue(getElementCurrentValueSnapshot(resolved.element));
+          if (normalizeSurveyAgentValue(desiredText) === currentSnapshot) {
+            const label = getElementLabelText(resolved.element);
+            return {
+              ok: true,
+              code: 'act_inputText_ok',
+              details: {
+                index: locator.highlightIndex,
+                text: desiredText,
+                identityKey: valueInfo.usedIdentity ? valueInfo.identityKey : undefined,
+                question: label || undefined,
+                skipped: true,
+              },
+            };
+          }
+          const textToType = desiredText;
+          await typeValueIntoElement(resolved.element, textToType, {
+            typingSpeed: action.typingSpeed,
+            replace: action.replace !== false,
+          });
+          const label = getElementLabelText(resolved.element);
+          return {
+            ok: true,
+            code: 'act_inputText_ok',
+            details: {
+              index: locator.highlightIndex,
+              text: textToType,
+              identityKey: valueInfo.usedIdentity ? valueInfo.identityKey : undefined,
+              question: label || undefined,
+            },
+          };
+        }
+        case 'select': {
+          focusFrameElements(resolved.frameElements);
+          if (!resolved.element || resolved.element.tagName !== 'SELECT') {
+            return {
+              ok: false,
+              error: 'NOT_A_SELECT_ELEMENT',
+              code: 'act_selectDropdownOption_notSelect',
+              details: { tagName: resolved.element?.tagName, index: locator.highlightIndex },
+            };
+          }
+          const valueInfo = resolveSurveyAgentInputValue(action, resolved.element);
+          if (valueInfo.missingIdentity) {
+            return {
+              ok: false,
+              error: 'IDENTITY_VALUE_MISSING',
+              code: 'act_identity_missing',
+              details: { key: valueInfo.identityKey, index: locator.highlightIndex },
+            };
+          }
+          const desiredOption = valueInfo.text || action.text || '';
+          if (isSelectValueAlreadyChosen(resolved.element, desiredOption)) {
+            const selectionSnapshot = getSelectSelectionInfo(resolved.element);
+            const label = getElementLabelText(resolved.element);
+            return {
+              ok: true,
+              code: 'act_selectDropdownOption_ok',
+              details: {
+                index: locator.highlightIndex,
+                value: selectionSnapshot.value,
+                text: selectionSnapshot.text || desiredOption,
+                identityKey: valueInfo.usedIdentity ? valueInfo.identityKey : undefined,
+                question: label || undefined,
+                skipped: true,
+              },
+            };
+          }
+          const selection = selectOptionOnElement(resolved.element, valueInfo.text || action.text || '');
+          if (!selection.selected) {
+            return {
+              ok: false,
+              error: 'OPTION_NOT_FOUND',
+              code: 'act_selectDropdownOption_failed',
+              details: {
+                index: locator.highlightIndex,
+                text: valueInfo.text || action.text || '',
+                identityKey: valueInfo.identityKey,
+              },
+            };
+          }
+          const label = getElementLabelText(resolved.element);
+          return {
+            ok: true,
+            code: 'act_selectDropdownOption_ok',
+            details: {
+              index: locator.highlightIndex,
+              value: selection.value,
+              text: selection.text,
+              identityKey: valueInfo.usedIdentity ? valueInfo.identityKey : undefined,
+              question: label || undefined,
+            },
+          };
+        }
+        case 'scroll': {
+          const scrollDetails = performScrollAction(action, resolved);
+          return {
+            ok: true,
+            code: 'act_scroll_ok',
+            details: scrollDetails,
+          };
+        }
+        case 'ip_info':
+          return await handleSurveyAgentIpInfoAction(action);
+        case 'ip_check':
+          return await handleSurveyAgentIpQualificationAction(action);
+        case 'custom_open':
+          return await handleSurveyAgentCustomOpenAction(action);
+        default:
+          return { ok: false, error: `UNKNOWN_ACTION:${type}`, code: 'act_errors_unknownAction' };
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        error: err?.message || String(err),
+        code: action.intent || 'act_errors_unexpected',
+        details: { locator, reason: resolved?.reason },
+      };
+    }
+  }
+
+  function summarizeSurveyAgentIpInfo(info) {
+    if (!info || typeof info !== 'object') {
+      return 'تم عرض معلومات عنوان الـIP الحالي.';
+    }
+    const parts = [];
+    if (info.ip) parts.push(`العنوان: ${info.ip}`);
+    if (info.country && info.country !== 'Unknown') parts.push(`الدولة: ${info.country}`);
+    if (info.city && info.city !== 'Unknown') parts.push(`المدينة: ${info.city}`);
+    if (info.isp && info.isp !== 'Unknown') parts.push(`المزوّد: ${info.isp}`);
+    if (info.timezone && info.timezone !== 'Unknown') parts.push(`المنطقة: ${info.timezone}`);
+    return parts.length ? parts.join(' • ') : 'تم تحديث معلومات الـIP.';
+  }
+
+  function summarizeSurveyAgentIpQualification(data) {
+    if (!data || typeof data !== 'object') {
+      return 'تم عرض تقييم الـIP الحالي.';
+    }
+    const score = Number.isFinite(data.fraud_score) ? Math.round(data.fraud_score) : null;
+    const status = data.status || data.ip_quality || data.result;
+    const vpn = data.vpn || data.proxy || data.recent_abuse;
+    const parts = [];
+    if (score !== null) parts.push(`التقييم: ${score}/100`);
+    if (status) parts.push(`الحالة: ${status}`);
+    if (typeof vpn === 'string') {
+      parts.push(`VPN/Proxy: ${vpn}`);
+    } else if (typeof vpn === 'boolean') {
+      parts.push(vpn ? 'يبدو أنه VPN/Proxy' : 'لا يوجد VPN ظاهر');
+    }
+    return parts.length ? parts.join(' • ') : 'تم تحديث نتيجة التأهيل.';
+  }
+
+  async function handleSurveyAgentIpInfoAction(action = {}) {
+    try {
+      const response = await chrome.runtime.sendMessage({ type: 'GET_PUBLIC_IP' });
+      if (!response?.ok) {
+        return {
+          ok: false,
+          error: response?.error || 'IP_INFO_UNAVAILABLE',
+          code: 'act_ipInfo_failed',
+          details: {},
+        };
+      }
+      const info = response.info || {};
+      showIPModal(info);
+      const summary = summarizeSurveyAgentIpInfo(info);
+      return {
+        ok: true,
+        code: 'act_ipInfo_ok',
+        details: { summary, info },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err?.message || String(err),
+        code: 'act_ipInfo_failed',
+        details: {},
+      };
+    }
+  }
+
+  async function handleSurveyAgentIpQualificationAction(action = {}) {
+    try {
+      let data = null;
+      try {
+        const response = await chrome.runtime.sendMessage({ type: 'GET_IP_QUALIFICATION' });
+        if (response?.ok) {
+          data = response.data || null;
+          if (data) {
+            await chrome.storage.local.set({ lastIPQ: data });
+          }
+        }
+      } catch (err) {
+        // swallow and fall back to cached value
+      }
+      if (!data) {
+        const { lastIPQ } = await chrome.storage.local.get('lastIPQ');
+        data = lastIPQ || null;
+      }
+      showCleanIPQualificationModal(data || null);
+      const summary = summarizeSurveyAgentIpQualification(data);
+      return {
+        ok: true,
+        code: 'act_ipCheck_ok',
+        details: { summary, data },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err?.message || String(err),
+        code: 'act_ipCheck_failed',
+        details: {},
+      };
+    }
+  }
+
+  async function resolveSurveyAgentCustomUrl(siteKey) {
+    if (!siteKey) return null;
+    const key = String(siteKey).toLowerCase();
+    try {
+      const { customSites = [] } = await chrome.storage.local.get('customSites');
+      const match = customSites.find((site) => {
+        if (!site) return false;
+        const name = (site.name || '').toLowerCase();
+        const url = (site.url || '').toLowerCase();
+        return name === key || url.includes(key);
+      });
+      return match?.url || null;
+    } catch (err) {
+      console.warn('Survey agent: failed to resolve custom site', err);
+      return null;
+    }
+  }
+
+  async function handleSurveyAgentCustomOpenAction(action = {}) {
+    try {
+      let targetUrl = action.url;
+      if (!targetUrl && action.siteKey) {
+        targetUrl = await resolveSurveyAgentCustomUrl(action.siteKey);
+      }
+      let payload;
+      if (targetUrl) {
+        payload = { type: 'OPEN_OR_FOCUS_CUSTOM_WEB', url: targetUrl };
+      } else {
+        payload = { type: 'OPEN_CUSTOM_WEB' };
+      }
+      const response = await chrome.runtime.sendMessage(payload);
+      if (!response?.ok) {
+        return {
+          ok: false,
+          error: response?.error || 'CUSTOM_WEB_FAILED',
+          code: 'act_customOpen_failed',
+          details: { url: targetUrl || null },
+        };
+      }
+      return {
+        ok: true,
+        code: 'act_customOpen_ok',
+        details: { url: targetUrl || null, focused: Boolean(response.focused) },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err?.message || String(err),
+        code: 'act_customOpen_failed',
+        details: { url: action.url || null },
+      };
+    }
+  }
 
   // Identity handling
   const FIELD_KEYWORDS = {
@@ -53,7 +3512,6 @@ function init() {
     companyAddress: ['company_address','business_address','work_address','office_address','corporate_address','company_location','workplace_address','company_addr',/office.?address|business.?addr/]
   };
 
-  let activeIdentity = null;
   function loadIdentity(){
     chrome.storage.local.get(['activeIdentityId','identities'], res => {
       const list = res.identities || [];
@@ -64,6 +3522,14 @@ function init() {
   chrome.storage.onChanged.addListener((chg, area)=>{
     if(area==='local' && (chg.activeIdentityId || chg.identities)){
       loadIdentity();
+    }
+  });
+  chrome.storage.onChanged.addListener((chg, area) => {
+    if (area === 'local' && chg[SURVEY_AGENT_SETTINGS_KEY]) {
+      const next = chg[SURVEY_AGENT_SETTINGS_KEY].newValue;
+      if (next && typeof next === 'object') {
+        applySurveyAgentSettings(next);
+      }
     }
   });
   loadIdentity();
@@ -92,11 +3558,7 @@ function init() {
   function detectField(el){
     if(!el) return null;
     const attrs = ((el.id||'') + ' ' + (el.name||'') + ' ' + (el.placeholder||'') + ' ' + (el.type||'')).toLowerCase();
-    let labelText = '';
-    if(el.id){
-      const lbl = document.querySelector(`label[for="${CSS.escape(el.id)}"]`);
-      if(lbl) labelText = lbl.textContent.toLowerCase();
-    }
+    const labelText = getElementLabelText(el).toLowerCase();
     const hay = attrs + ' ' + labelText;
     for(const [key, vals] of Object.entries(FIELD_KEYWORDS)){
       if(vals.some(v=> v instanceof RegExp ? v.test(hay) : hay.includes(v))) return key;
@@ -401,6 +3863,7 @@ function init() {
           <li><a href="#" data-action="ocr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="12" cy="12" r="3"/></svg><span>OCR Capture</span></a></li>
           <li><a href="#" data-action="ocr-full"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="16" y1="2" x2="16" y2="6"/></svg><span>OCR Full Page</span></a></li>
           <li><a href="#" data-action="write-last"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg><span>Write Last Answer</span></a></li>
+          <li><a href="#" data-action="survey-agent"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="18" height="10" rx="2"/><path d="M12 7V3"/><path d="M8 11h.01"/><path d="M16 11h.01"/><path d="M8 15h8"/></svg><span>وكيل الاستبيانات</span></a></li>
           <li><a href="#" data-action="clear-context"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Clear AI Context</span></a></li>
           <li><a href="#" data-action="ip-info"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg><span>IP Information</span></a></li>
           <li><a href="#" data-action="ip-qual"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg><span>IP Qualification</span></a></li>
@@ -628,6 +4091,9 @@ function init() {
         } catch (e) {
           showNotification('No last answer available');
         }
+        break;
+      case 'survey-agent':
+        openSurveyAgentPanel();
         break;
       case 'clear-context':
         await chrome.storage.local.set({ contextQA: [] });
@@ -3619,6 +7085,80 @@ function init() {
     }, 100);
   }
 
+  function createSurveyAgentPanel(title, bodyHtml, onClose) {
+    const existing = document.getElementById('zepra-survey-agent-panel');
+    if (existing && existing.isConnected) {
+      if (typeof existing.__zepraCleanup === 'function') {
+        try {
+          existing.__zepraCleanup();
+        } catch (err) {
+          // ignore cleanup failures
+        }
+      }
+      if (typeof existing.__zepraOnClose === 'function') {
+        try {
+          existing.__zepraOnClose();
+        } catch (err) {
+          // ignore stale callbacks
+        }
+      }
+      existing.remove();
+    }
+
+    const panel = document.createElement('aside');
+    panel.id = 'zepra-survey-agent-panel';
+    panel.setAttribute('role', 'complementary');
+    panel.setAttribute('aria-label', title);
+    panel.innerHTML = bodyHtml || '';
+
+    const closeBtn = panel.querySelector('.survey-agent-close');
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closePanel();
+      }
+    };
+
+    const closePanel = () => {
+      panel.classList.remove('is-open');
+      panel.classList.add('is-closing');
+      panel.__zepraCleanup?.();
+      setTimeout(() => {
+        if (panel.isConnected) {
+          panel.remove();
+        }
+        panel.__zepraOnClose?.();
+      }, 220);
+    };
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closePanel);
+    }
+
+    panel.__zepraCleanup = () => {
+      window.removeEventListener('keydown', handleEscape, true);
+      if (closeBtn) {
+        closeBtn.removeEventListener('click', closePanel);
+      }
+    };
+
+    panel.__zepraOnClose = () => {
+      if (typeof onClose === 'function') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape, true);
+
+    document.body.appendChild(panel);
+    requestAnimationFrame(() => {
+      panel.classList.add('is-open');
+    });
+
+    return panel;
+  }
+
   function createStyledModal(title, content, onClose) {
     // Remove existing modal
     const existing = document.getElementById('zepra-styled-modal');
@@ -3784,15 +7324,23 @@ function init() {
             <div class="loading"></div>
             ${showReasoning ? `
             <div class="split-pane" style="display:none;">
-              <div class="pane answer-pane">
-                <div class="pane-title">Answer</div>
-                <div class="answer-text"></div>
-                <button class="btn-copy-answer">Copy</button>
+              <div class="pane-card answer-pane">
+                <div class="pane-header">
+                  <div class="pane-title">Answer</div>
+                  <button class="pane-copy btn-copy-answer" type="button">Copy</button>
+                </div>
+                <div class="pane-body">
+                  <div class="pane-text answer-text"></div>
+                </div>
               </div>
-              <div class="pane reason-pane">
-                <div class="pane-title">Reason</div>
-                <div class="reason-text"></div>
-                <button class="btn-copy-reason">Copy</button>
+              <div class="pane-card reason-pane">
+                <div class="pane-header">
+                  <div class="pane-title">Reason</div>
+                  <button class="pane-copy btn-copy-reason" type="button">Copy</button>
+                </div>
+                <div class="pane-body">
+                  <div class="pane-text reason-text"></div>
+                </div>
               </div>
             </div>
             ` : `
@@ -3872,10 +7420,191 @@ function init() {
         to { opacity: 1; }
       }
 
-      .answer-container.split .split-pane{display:flex;gap:10px;}
-      .answer-container.split .pane{flex:1;background:#1f1f1f;padding:10px;border-radius:6px;display:flex;flex-direction:column;}
-      .answer-container.split .pane-title{font-weight:bold;margin-bottom:6px;}
-      .answer-container.split .pane button{align-self:flex-end;margin-top:8px;}
+      .answer-container.split .split-pane {
+        display:grid;
+        gap:1rem;
+        grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+      }
+
+      .answer-container.split .pane-card {
+        position:relative;
+        display:flex;
+        flex-direction:column;
+        gap:0.75rem;
+        padding:1.15rem;
+        min-height:200px;
+        border-radius:1rem;
+        border:1px solid rgba(148,163,184,0.22);
+        background:linear-gradient(165deg, rgba(12,18,32,0.94), rgba(17,24,39,0.82));
+        box-shadow:0 24px 45px -35px rgba(15,23,42,0.95), 0 0 0 1px rgba(15,23,42,0.6);
+        backdrop-filter:blur(12px);
+        overflow:hidden;
+      }
+
+      .answer-container.split .pane-card::before {
+        content:'';
+        position:absolute;
+        inset:-1px;
+        border-radius:inherit;
+        background:radial-gradient(circle at 20% -10%, rgba(59,130,246,0.18), transparent 60%);
+        opacity:0.85;
+        pointer-events:none;
+        z-index:0;
+      }
+
+      .answer-container.split .answer-pane::before {
+        background:radial-gradient(circle at 20% -10%, rgba(45,212,191,0.3), transparent 60%);
+      }
+
+      .answer-container.split .reason-pane::before {
+        background:radial-gradient(circle at 20% -10%, rgba(250,204,21,0.32), rgba(244,114,182,0.22) 55%, transparent 80%);
+      }
+
+      .answer-container.split .pane-card > * {
+        position:relative;
+        z-index:1;
+      }
+
+      .answer-container.split .answer-pane {
+        border-color:rgba(45,212,191,0.35);
+        box-shadow:0 24px 40px -32px rgba(20,184,166,0.55), 0 0 0 1px rgba(20,184,166,0.3);
+      }
+
+      .answer-container.split .reason-pane {
+        border-color:rgba(244,114,182,0.4);
+        background:linear-gradient(170deg, rgba(23,16,32,0.95), rgba(27,20,35,0.82));
+        box-shadow:0 24px 40px -32px rgba(236,72,153,0.55), 0 0 0 1px rgba(236,72,153,0.28);
+      }
+
+      .answer-container.split .pane-header {
+        display:flex;
+        align-items:center;
+        justify-content:space-between;
+        gap:0.75rem;
+        padding-bottom:0.5rem;
+        border-bottom:1px solid rgba(148,163,184,0.18);
+        flex-wrap:wrap;
+      }
+
+      .answer-container.split .pane-title {
+        margin:0;
+        font-weight:700;
+        font-size:0.85rem;
+        letter-spacing:0.08em;
+        text-transform:uppercase;
+        color:#bae6fd;
+        line-height:1.1;
+      }
+
+      .answer-container.split .answer-pane .pane-title {
+        color:#5eead4;
+        text-shadow:0 0 12px rgba(94,234,212,0.35);
+      }
+
+      .answer-container.split .reason-pane .pane-title {
+        color:#f9a8d4;
+        text-shadow:0 0 12px rgba(244,114,182,0.35);
+      }
+
+      .answer-container.split .answer-pane .pane-header {
+        border-color:rgba(45,212,191,0.2);
+      }
+
+      .answer-container.split .reason-pane .pane-header {
+        border-color:rgba(244,114,182,0.24);
+      }
+
+      .answer-container.split .pane-body {
+        flex:1;
+        padding:0.9rem;
+        border-radius:0.85rem;
+        background:linear-gradient(160deg, rgba(10,16,28,0.85), rgba(15,23,42,0.7));
+        border:1px solid rgba(148,163,184,0.18);
+        box-shadow:inset 0 0 0 1px rgba(15,23,42,0.4);
+        overflow-y:auto;
+        max-height:min(300px,40vh);
+      }
+
+      .answer-container.split .answer-pane .pane-body {
+        border-color:rgba(45,212,191,0.28);
+        box-shadow:inset 0 0 0 1px rgba(13,148,136,0.3);
+      }
+
+      .answer-container.split .reason-pane .pane-body {
+        border-color:rgba(244,114,182,0.3);
+        box-shadow:inset 0 0 0 1px rgba(244,114,182,0.25);
+        background:linear-gradient(160deg, rgba(23,16,32,0.92), rgba(27,20,35,0.82));
+      }
+
+      .answer-container.split .pane-body::-webkit-scrollbar {
+        width:6px;
+      }
+
+      .answer-container.split .pane-body::-webkit-scrollbar-track {
+        background:transparent;
+      }
+
+      .answer-container.split .answer-pane .pane-body::-webkit-scrollbar-thumb {
+        background:rgba(45,212,191,0.45);
+      }
+
+      .answer-container.split .reason-pane .pane-body::-webkit-scrollbar-thumb {
+        background:rgba(244,114,182,0.55);
+      }
+
+      .answer-container.split .pane-text {
+        color:#f8fafc;
+        font-size:0.95rem;
+        line-height:1.6;
+        white-space:pre-wrap;
+        word-break:break-word;
+        text-align:start;
+        unicode-bidi:plaintext;
+      }
+
+      .answer-container.split .pane-copy {
+        border:none;
+        border-radius:999px;
+        padding:0.4rem 0.95rem;
+        font-size:0.7rem;
+        letter-spacing:0.08em;
+        text-transform:uppercase;
+        font-weight:600;
+        cursor:pointer;
+        transition:transform .2s ease, box-shadow .2s ease, background .2s ease;
+        color:#f8fafc;
+        background:rgba(148,163,184,0.24);
+        flex-shrink:0;
+      }
+
+      .answer-container.split .pane-copy:hover {
+        transform:translateY(-1px);
+      }
+
+      .answer-container.split .pane-copy:focus-visible {
+        outline:2px solid rgba(250,204,21,0.6);
+        outline-offset:2px;
+      }
+
+      .answer-container.split .answer-pane .pane-copy {
+        background:rgba(45,212,191,0.22);
+        color:#5eead4;
+        box-shadow:0 10px 25px -20px rgba(20,184,166,0.8), 0 0 0 1px rgba(45,212,191,0.35);
+      }
+
+      .answer-container.split .answer-pane .pane-copy:hover {
+        background:rgba(45,212,191,0.32);
+      }
+
+      .answer-container.split .reason-pane .pane-copy {
+        background:rgba(244,114,182,0.22);
+        color:#f9a8d4;
+        box-shadow:0 10px 25px -20px rgba(236,72,153,0.8), 0 0 0 1px rgba(244,114,182,0.35);
+      }
+
+      .answer-container.split .reason-pane .pane-copy:hover {
+        background:rgba(244,114,182,0.32);
+      }
 
       .za-modal {
         background-color: rgba(17,24,39,0.8);
@@ -3952,10 +7681,15 @@ function init() {
         min-height:60px;
       }
 
-      .answer-text {
+      .answer-container:not(.split) .answer-text {
         display:none;
         flex-direction:column;
         gap:0.75rem;
+      }
+
+      .answer-container.split .answer-text,
+      .answer-container.split .reason-text {
+        display:block;
       }
 
       .answer-card {
@@ -4086,9 +7820,23 @@ function init() {
         loadEl.style.display = 'none';
         if (useReason) {
           const split = modal.querySelector('.split-pane');
-          split.style.display = 'flex';
-          modal.querySelector('.answer-pane .answer-text').textContent = answer;
-          modal.querySelector('.reason-pane .reason-text').textContent = reason;
+          split.style.display = 'grid';
+          const answerEl = modal.querySelector('.answer-pane .answer-text');
+          const reasonEl = modal.querySelector('.reason-pane .reason-text');
+          const answerBody = modal.querySelector('.answer-pane .pane-body');
+          const reasonBody = modal.querySelector('.reason-pane .pane-body');
+          if (answerEl) {
+            answerEl.textContent = answer;
+            answerEl.style.display = 'block';
+            answerEl.setAttribute('dir', 'auto');
+          }
+          if (reasonEl) {
+            reasonEl.textContent = reason;
+            reasonEl.style.display = 'block';
+            reasonEl.setAttribute('dir', 'auto');
+          }
+          if (answerBody) answerBody.scrollTop = 0;
+          if (reasonBody) reasonBody.scrollTop = 0;
           modal.querySelector('.modal-actions').style.display = 'flex';
           modal.querySelector('.btn-copy-answer').addEventListener('click', () => {
             navigator.clipboard.writeText(answer);
@@ -4304,6 +8052,23 @@ function init() {
           case 'GET_SELECTED_OR_DOM_TEXT':
             sendResponse({ ok: true, text: getSelectedOrDomText() });
             break;
+          case 'SURVEY_AGENT_COLLECT_DOM': {
+            const domTree = await collectSurveyDomTree(msg.options || {});
+            sendResponse({ ok: true, tree: domTree });
+            break;
+          }
+          case 'SURVEY_AGENT_EXECUTE_ACTION': {
+            const result = await executeSurveyAgentAction(msg.action || {});
+            sendResponse(result);
+            break;
+          }
+          case 'SURVEY_AGENT_STATUS_UPDATE': {
+            if (msg.message) {
+              setSurveyAgentStatusMessage(String(msg.message), msg.tone || 'status');
+            }
+            sendResponse({ ok: true });
+            break;
+          }
           case 'START_OCR_SELECTION': {
             const rect = await showOverlayAndSelect();
             sendResponse({ ok: true, rect });
@@ -4547,9 +8312,12 @@ chrome.storage.onChanged.addListener((chg, area) => {
 });
 
 // Clean Professional IP Qualification Modal
-function showCleanIPQualificationModal(data){
-  if(!data){
-    createStyledModal('IP Qualification', `<div style="padding:20px;text-align:center;color:#e2e8f0;">Could not fetch IP data. Please try again.</div>`);
+function showCleanIPQualificationModal(data) {
+  if (!data) {
+    createStyledModal(
+      'IP Qualification',
+      `<div style="padding:20px;text-align:center;color:#e2e8f0;">Could not fetch IP data. Please try again.</div>`
+    );
     return;
   }
 
@@ -4558,31 +8326,35 @@ function showCleanIPQualificationModal(data){
   const city = data.city || data.region_name || data.region || '';
   const cc = (data.country_code || data.countryCode || data.country_code2 || '').toUpperCase();
   const isp = data.isp || data.org || '';
-  const flag = cc ? cc.replace(/./g, ch => String.fromCodePoint(127397 + ch.charCodeAt(0))) : '';
+  const flag = cc ? cc.replace(/./g, (ch) => String.fromCodePoint(127397 + ch.charCodeAt(0))) : '';
 
   const detection = data?.blacklists?.detection || 'none';
+  const detectionEngines = Array.isArray(data?.blacklists?.engines)
+    ? data.blacklists.engines
+        .filter((engine) => engine?.listed)
+        .map((engine) => engine?.name || engine?.engine)
+        .filter(Boolean)
+    : [];
   const proxy = !!data?.security?.proxy;
   const vpn = !!data?.security?.vpn;
   const tor = !!data?.security?.tor;
 
-  // Enhanced status logic with three states
   const riskPass = risk < 30;
   const riskWarning = risk >= 30 && risk <= 50;
   const riskFail = risk > 50;
-  const blacklistPass = detection === 'none';
+  const blacklistPass = detection === 'none' && detectionEngines.length === 0;
   const anonymityPass = !proxy && !vpn && !tor;
 
-  // Determine overall status
   let statusState = 'qualified';
-  let statusText = 'QUALIFIED';
+  let statusText = 'Qualified';
   let statusMessage = 'Your IP is clean and ready to use.';
   let statusClass = 'status-qualified';
 
   if (riskFail || !blacklistPass || !anonymityPass) {
     statusState = 'not-qualified';
-    statusText = 'NOT QUALIFIED';
+    statusText = 'Not Qualified';
     statusClass = 'status-not-qualified';
-    
+
     if (riskFail) {
       statusMessage = 'Warning: This IP is high-risk and has a bad reputation. It is not recommended for use.';
     } else if (!blacklistPass) {
@@ -4592,292 +8364,470 @@ function showCleanIPQualificationModal(data){
     }
   } else if (riskWarning) {
     statusState = 'warning';
-    statusText = 'WARNING';
+    statusText = 'Warning';
     statusClass = 'status-warning';
     statusMessage = 'Your IP is moderately risky. Proceed with caution.';
   }
 
-  // SVG Icons
   const shieldSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>`;
   const eyeSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>`;
   const globeSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
-  
-  // Status-specific icons
-  const checkSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="check-icon"><polyline points="20 6 9 17 4 12"/></svg>`;
-  const warningSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="warning-icon"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="m12 17 .01 0"/></svg>`;
-  const xSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="x-icon"><path d="M18 6 6 18M6 6l12 12"/></svg>`;
+  const copySVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
 
-  // Build clean checklist
+  const checkSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+  const warningSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="m12 17 .01 0"/></svg>`;
+  const xSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>`;
+  const checkCompactSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+  const detectionSources = detectionEngines.length
+    ? detectionEngines
+    : detection !== 'none' && detection
+      ? [detection]
+      : [];
+  const formattedSources = detectionSources
+    .map((src) => src.replace(/[_-]+/g, ' '))
+    .map((src) => src.replace(/\b\w/g, (ch) => ch.toUpperCase()));
+
+  const riskDetail = riskFail
+    ? `High risk score detected • ${risk}/100`
+    : riskWarning
+      ? `Moderate risk profile • ${risk}/100`
+      : `Low risk score • ${risk}/100`;
+  const blacklistDetail = blacklistPass
+    ? 'No blacklist matches detected'
+    : `Listed on ${formattedSources.join(', ') || 'reported sources'}`;
+  const anonymityFlags = [];
+  if (proxy) anonymityFlags.push('Proxy');
+  if (vpn) anonymityFlags.push('VPN');
+  if (tor) anonymityFlags.push('Tor');
+  const anonymityDetail = anonymityPass
+    ? 'No proxy, VPN or Tor activity detected'
+    : `Detected: ${anonymityFlags.join(', ') || 'Anonymity services'}`;
+
   const checks = [
-    { 
-      pass: riskPass, 
-      warning: riskWarning,
-      fail: riskFail,
-      label: 'Risk Score Assessment', 
-      icon: shieldSVG 
+    {
+      key: 'risk',
+      label: 'Risk Score Assessment',
+      detail: riskDetail,
+      state: riskFail ? 'fail' : riskWarning ? 'warn' : 'pass',
+      icon: shieldSVG
     },
-    { 
-      pass: blacklistPass, 
-      warning: false,
-      fail: !blacklistPass,
-      label: 'Blacklist Verification', 
-      icon: eyeSVG 
+    {
+      key: 'blacklist',
+      label: 'Blacklist Verification',
+      detail: blacklistDetail,
+      state: blacklistPass ? 'pass' : 'fail',
+      icon: eyeSVG
     },
-    { 
-      pass: anonymityPass, 
-      warning: false,
-      fail: !anonymityPass,
-      label: 'Anonymity Detection', 
-      icon: globeSVG 
-    },
+    {
+      key: 'anonymity',
+      label: 'Anonymity Detection',
+      detail: anonymityDetail,
+      state: anonymityPass ? 'pass' : 'fail',
+      icon: globeSVG
+    }
   ];
 
-  const checklistHTML = checks
-    .map((c, i) => {
-      let resultIcon = checkSVG;
-      let resultClass = 'check-result-pass';
-      
-      if (c.fail) {
-        resultIcon = xSVG;
-        resultClass = 'check-result-fail';
-      } else if (c.warning) {
-        resultIcon = warningSVG;
-        resultClass = 'check-result-warning';
-      }
-      
+  const stateBadges = {
+    pass: { label: 'Passed', icon: checkSVG },
+    warn: { label: 'Attention', icon: warningSVG },
+    fail: { label: 'Failed', icon: xSVG }
+  };
+
+  const checkHTML = checks
+    .map((item) => {
+      const badge = stateBadges[item.state];
       return `
-      <div class="ipq-check-item ${resultClass}" style="--i:${i};">
-        <div class="ipq-check-left">${c.icon}<span>${c.label}</span></div>
-        <div class="ipq-check-result">${resultIcon}</div>
-      </div>`;
+        <div class="ipq-check-card ipq-${item.state}">
+          <div class="ipq-check-left">
+            <div class="ipq-check-icon">${item.icon}</div>
+            <div class="ipq-check-titles">
+              <span class="ipq-check-title">${item.label}</span>
+              <span class="ipq-check-detail">${item.detail}</span>
+            </div>
+          </div>
+          <div class="ipq-check-status">${badge.icon}<span>${badge.label}</span></div>
+        </div>`;
     })
     .join('');
 
-  // Header icons based on status
+  const locationParts = [city, cc].filter(Boolean).join(', ');
+  const locationDisplay = locationParts ? `${flag ? `${flag} ` : ''}${locationParts}` : 'Unknown';
+  const ispDisplay = isp || 'Unknown';
+
+  const html = `
+    <style>
+      #zepra-styled-modal .styled-modal-content.ipq-shell {
+        background: linear-gradient(180deg, rgba(15,23,42,0.95) 0%, rgba(11,15,25,0.92) 100%);
+        border: none;
+        border-radius: 20px;
+        box-shadow: 0 25px 50px -12px rgba(15,23,42,0.8);
+        max-width: 420px;
+        width: min(420px, 92vw);
+        overflow: hidden;
+      }
+      #zepra-styled-modal .ipq-shell {
+        --ipq-accent: #22c55e;
+        --ipq-accent-soft: rgba(34,197,94,0.2);
+        --ipq-accent-strong: rgba(34,197,94,0.35);
+      }
+      #zepra-styled-modal .ipq-shell.status-warning {
+        --ipq-accent: #f59e0b;
+        --ipq-accent-soft: rgba(245,158,11,0.18);
+        --ipq-accent-strong: rgba(245,158,11,0.32);
+      }
+      #zepra-styled-modal .ipq-shell.status-not-qualified {
+        --ipq-accent: #ef4444;
+        --ipq-accent-soft: rgba(239,68,68,0.18);
+        --ipq-accent-strong: rgba(239,68,68,0.32);
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-header {
+        background: linear-gradient(90deg, rgba(148,163,184,0.14), rgba(148,163,184,0));
+        border-bottom: 1px solid rgba(148,163,184,0.18);
+        padding: 18px 22px;
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-header h3 {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin: 0;
+        color: #f8fafc;
+        font-size: 17px;
+        font-weight: 700;
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-header svg {
+        width: 22px;
+        height: 22px;
+        stroke: var(--ipq-accent);
+        color: var(--ipq-accent);
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-close {
+        color: #94a3b8;
+        border-radius: 10px;
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-close:hover {
+        background: rgba(148,163,184,0.16);
+        color: #e2e8f0;
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-body {
+        padding: 1.5rem;
+        background: radial-gradient(circle at top, rgba(30,41,59,0.65), rgba(15,23,42,0.92));
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        max-height: 65vh;
+        overflow-y: auto;
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-body::-webkit-scrollbar {
+        width: 6px;
+      }
+      #zepra-styled-modal .ipq-shell .styled-modal-body::-webkit-scrollbar-thumb {
+        background: rgba(148,163,184,0.35);
+        border-radius: 999px;
+      }
+      .ipq-status-card {
+        background: rgba(15,23,42,0.55);
+        border: 1px solid rgba(148,163,184,0.2);
+        border-radius: 1rem;
+        padding: 1.2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        box-shadow: inset 0 0 0 1px rgba(15,23,42,0.35);
+      }
+      .ipq-status-top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .ipq-status-head {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        min-width: 0;
+      }
+      .ipq-status-label {
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.14em;
+        font-weight: 600;
+        color: var(--ipq-accent);
+      }
+      .ipq-status-message {
+        margin: 0;
+        color: #e2e8f0;
+        font-size: 0.92rem;
+        line-height: 1.45;
+      }
+      .ipq-risk-block {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.25rem;
+        min-width: 0;
+      }
+      .ipq-risk-caption {
+        font-size: 0.72rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: #94a3b8;
+      }
+      .ipq-risk-value {
+        font-size: 2.6rem;
+        font-weight: 700;
+        color: var(--ipq-accent);
+        font-family: 'Fira Code', 'SFMono-Regular', Menlo, Consolas, monospace;
+        line-height: 1;
+      }
+      .ipq-meta-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 0.75rem;
+      }
+      .ipq-meta-card {
+        background: rgba(15,23,42,0.5);
+        border: 1px solid rgba(148,163,184,0.18);
+        border-radius: 0.9rem;
+        padding: 0.85rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        min-width: 0;
+      }
+      .ipq-meta-card.ipq-span {
+        grid-column: span 2;
+      }
+      .ipq-meta-label {
+        font-size: 0.72rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: #94a3b8;
+      }
+      .ipq-meta-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      .ipq-meta-value {
+        color: #f8fafc;
+        font-weight: 600;
+        word-break: break-word;
+      }
+      .ipq-ip-value {
+        font-family: 'Fira Code', 'SFMono-Regular', Menlo, Consolas, monospace;
+        font-size: 1.1rem;
+        color: var(--ipq-accent);
+      }
+      .ipq-copy-btn {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.75rem;
+        background: rgba(148,163,184,0.12);
+        border: 1px solid rgba(148,163,184,0.28);
+        color: #e2e8f0;
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+      .ipq-copy-btn:hover {
+        background: rgba(148,163,184,0.24);
+      }
+      .ipq-copy-btn svg {
+        width: 14px;
+        height: 14px;
+      }
+      .ipq-copy-btn.copied {
+        background: var(--ipq-accent-soft);
+        border-color: var(--ipq-accent);
+        color: var(--ipq-accent);
+      }
+      .ipq-copy-btn.error {
+        background: rgba(239,68,68,0.18);
+        border-color: rgba(239,68,68,0.4);
+        color: #f87171;
+      }
+      .ipq-check-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      .ipq-check-card {
+        background: rgba(15,23,42,0.48);
+        border: 1px solid rgba(148,163,184,0.16);
+        border-radius: 0.9rem;
+        padding: 0.95rem 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        min-width: 0;
+      }
+      .ipq-check-left {
+        display: flex;
+        align-items: center;
+        gap: 0.8rem;
+        min-width: 0;
+      }
+      .ipq-check-icon {
+        width: 34px;
+        height: 34px;
+        border-radius: 0.8rem;
+        background: rgba(148,163,184,0.12);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+      .ipq-check-icon svg {
+        width: 18px;
+        height: 18px;
+        stroke-width: 2;
+      }
+      .ipq-check-titles {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        min-width: 0;
+      }
+      .ipq-check-title {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #f8fafc;
+      }
+      .ipq-check-detail {
+        color: #94a3b8;
+        font-size: 0.82rem;
+        line-height: 1.35;
+      }
+      .ipq-check-status {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-weight: 600;
+        font-size: 0.85rem;
+        flex-shrink: 0;
+      }
+      .ipq-check-status svg {
+        width: 18px;
+        height: 18px;
+      }
+      .ipq-check-card.ipq-pass .ipq-check-icon {
+        background: var(--ipq-accent-soft);
+        color: var(--ipq-accent);
+      }
+      .ipq-check-card.ipq-pass .ipq-check-status {
+        color: var(--ipq-accent);
+      }
+      .ipq-check-card.ipq-warn .ipq-check-icon {
+        background: rgba(245,158,11,0.18);
+        color: #f59e0b;
+      }
+      .ipq-check-card.ipq-warn .ipq-check-status {
+        color: #f59e0b;
+      }
+      .ipq-check-card.ipq-fail .ipq-check-icon {
+        background: rgba(239,68,68,0.18);
+        color: #ef4444;
+      }
+      .ipq-check-card.ipq-fail .ipq-check-status {
+        color: #ef4444;
+      }
+      .ipq-footer-note {
+        font-size: 0.75rem;
+        color: #64748b;
+        text-align: center;
+      }
+      @media (max-width: 520px) {
+        #zepra-styled-modal .ipq-shell .styled-modal-body {
+          padding: 1.25rem;
+        }
+        .ipq-status-top {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .ipq-risk-block {
+          align-items: flex-start;
+        }
+        .ipq-meta-card.ipq-span {
+          grid-column: span 1;
+        }
+      }
+    </style>
+    <div class="ipq-body">
+      <section class="ipq-status-card">
+        <div class="ipq-status-top">
+          <div class="ipq-status-head">
+            <span class="ipq-status-label">${statusText.toUpperCase()}</span>
+            <p class="ipq-status-message">${statusMessage}</p>
+          </div>
+          <div class="ipq-risk-block">
+            <span class="ipq-risk-caption">Risk Score</span>
+            <span class="ipq-risk-value">${risk}</span>
+          </div>
+        </div>
+      </section>
+      <section class="ipq-meta-grid">
+        <div class="ipq-meta-card ipq-span">
+          <div class="ipq-meta-label">IP Address</div>
+          <div class="ipq-meta-row">
+            <span class="ipq-meta-value ipq-ip-value">${ip || 'Unknown'}</span>
+            ${ip ? `<button class="ipq-copy-btn" data-copy="${ip}">${copySVG}<span>Copy</span></button>` : ''}
+          </div>
+        </div>
+        <div class="ipq-meta-card">
+          <div class="ipq-meta-label">Location</div>
+          <div class="ipq-meta-value">${locationDisplay}</div>
+        </div>
+        <div class="ipq-meta-card">
+          <div class="ipq-meta-label">ISP</div>
+          <div class="ipq-meta-value">${ispDisplay}</div>
+        </div>
+      </section>
+      <section class="ipq-check-grid">${checkHTML}</section>
+      <p class="ipq-footer-note">Scores are provided by ip-score.com and refreshed on each request.</p>
+    </div>`;
+
   const shieldCheckSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>`;
   const shieldWarningSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 7v6"/><path d="m12 17 .01 0"/></svg>`;
   const shieldOffSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 9l6 6M15 9l-6 6"/></svg>`;
-  
+
   let headerIcon = shieldCheckSVG;
   if (statusState === 'warning') headerIcon = shieldWarningSVG;
   else if (statusState === 'not-qualified') headerIcon = shieldOffSVG;
 
-  const html = `
-    <style>
-      /* Clean professional IP Qualification Modal */
-      .styled-modal-content.status-qualified { --ipq-color: #4ade80; }
-      .styled-modal-content.status-warning { --ipq-color: #fbbf24; }
-      .styled-modal-content.status-not-qualified { --ipq-color: #f43f5e; }
-      
-      /* Remove modal border and create clean look */
-      .styled-modal-content {
-        border: none !important;
-        box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5) !important;
-        background: rgba(20, 30, 48, 0.95) !important;
-        backdrop-filter: blur(20px) !important;
-      }
-
-      .ipq-modal {
-        position: relative;
-        max-width: 400px;
-        padding: 0;
-        background: transparent;
-        border: none;
-      }
-
-      .ipq-main {
-        padding: 32px 24px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 32px;
-      }
-
-      /* Central Status Circle - Main Visual Element */
-      .ipq-status-circle {
-        position: relative;
-        width: 160px;
-        height: 160px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        border: 3px solid var(--ipq-color);
-        border-radius: 50%;
-        background: rgba(0, 0, 0, 0.4);
-        box-shadow: 
-          0 0 30px var(--ipq-color),
-          inset 0 0 30px rgba(0, 0, 0, 0.5);
-        animation: circleGlow 2s ease-in-out infinite alternate;
-      }
-
-      @keyframes circleGlow {
-        from { 
-          box-shadow: 
-            0 0 30px var(--ipq-color),
-            inset 0 0 30px rgba(0, 0, 0, 0.5);
-        }
-        to { 
-          box-shadow: 
-            0 0 50px var(--ipq-color),
-            0 0 80px var(--ipq-color),
-            inset 0 0 30px rgba(0, 0, 0, 0.5);
-        }
-      }
-
-      .ipq-status-text {
-        font-size: 18px;
-        font-weight: 800;
-        color: var(--ipq-color);
-        text-shadow: 0 0 10px var(--ipq-color);
-        letter-spacing: 1px;
-        margin-bottom: 4px;
-      }
-
-      .ipq-risk-score {
-        font-size: 36px;
-        font-weight: 900;
-        color: var(--ipq-color);
-        text-shadow: 0 0 15px var(--ipq-color);
-        font-family: 'Courier New', monospace;
-      }
-
-      /* Simple Clean Checklist - No Boxes */
-      .ipq-checklist {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-        margin-top: 8px;
-      }
-
-      .ipq-check-item {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 12px 0;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        animation: itemFadeIn 0.5s ease forwards;
-        opacity: 0;
-        animation-delay: calc(var(--i) * 0.1s + 0.3s);
-      }
-
-      .ipq-check-item:last-child {
-        border-bottom: none;
-      }
-
-      @keyframes itemFadeIn {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-      }
-
-      .ipq-check-left {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-      }
-
-      .ipq-check-left svg {
-        width: 18px;
-        height: 18px;
-        stroke: #9ca3af;
-      }
-
-      .ipq-check-left span {
-        font-size: 14px;
-        font-weight: 500;
-        color: #e2e8f0;
-      }
-
-      .ipq-check-result svg {
-        width: 20px;
-        height: 20px;
-      }
-
-      /* Status Icons with Colors */
-      .check-result-pass .check-icon {
-        stroke: var(--ipq-color);
-        filter: drop-shadow(0 0 6px var(--ipq-color));
-      }
-
-      .check-result-warning .warning-icon {
-        stroke: var(--ipq-color);
-        fill: var(--ipq-color);
-        filter: drop-shadow(0 0 6px var(--ipq-color));
-      }
-
-      .check-result-fail .x-icon {
-        stroke: var(--ipq-color);
-        filter: drop-shadow(0 0 6px var(--ipq-color));
-      }
-
-      /* Clean Footer - Simple Text */
-      .ipq-footer {
-        width: 100%;
-        text-align: center;
-        margin-top: 24px;
-      }
-
-      .ipq-summary {
-        font-size: 14px;
-        font-weight: 600;
-        color: var(--ipq-color);
-        text-shadow: 0 0 8px var(--ipq-color);
-        margin-bottom: 16px;
-        animation: summaryFade 0.6s ease 0.8s both;
-      }
-
-      @keyframes summaryFade {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-      }
-
-      .ipq-info-text {
-        font-size: 13px;
-        color: #9ca3af;
-        line-height: 1.6;
-        animation: infoFade 0.6s ease 1s both;
-      }
-
-      .ipq-info-highlight {
-        color: var(--ipq-color);
-        font-weight: 600;
-      }
-
-      @keyframes infoFade {
-        from { opacity: 0; }
-        to { opacity: 1; }
-      }
-
-      /* Responsive */
-      @media (max-width: 480px) {
-        .ipq-modal { max-width: 95vw; }
-        .ipq-status-circle { width: 140px; height: 140px; }
-        .ipq-status-text { font-size: 16px; }
-        .ipq-risk-score { font-size: 28px; }
-      }
-    </style>
-    <div class="ipq-modal">
-      <main class="ipq-main">
-        <!-- Central Status Circle -->
-        <div class="ipq-status-circle">
-          <div class="ipq-status-text">${statusText}</div>
-          <div class="ipq-risk-score">${risk}</div>
-        </div>
-
-        <!-- Simple Clean Checklist -->
-        <div class="ipq-checklist">${checklistHTML}</div>
-
-        <!-- Clean Footer -->
-        <footer class="ipq-footer">
-          <div class="ipq-summary">${statusMessage}</div>
-          <div class="ipq-info-text">
-            <span class="ipq-info-highlight">${ip}</span> • ${flag} ${city ? city+', ' : ''}${cc} • ${isp || 'Unknown ISP'}
-          </div>
-        </footer>
-      </main>
-    </div>`;
-
   const modal = createStyledModal(`${headerIcon} IP Qualification`, html);
-  modal.querySelector('.styled-modal-content').classList.add(statusClass);
+  const shell = modal.querySelector('.styled-modal-content');
+  shell.classList.add('ipq-shell', statusClass);
+
+  const copyBtn = modal.querySelector('.ipq-copy-btn');
+  if (copyBtn && copyBtn.dataset.copy) {
+    const original = copyBtn.innerHTML;
+    copyBtn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(copyBtn.dataset.copy);
+        copyBtn.classList.remove('error');
+        copyBtn.classList.add('copied');
+        copyBtn.innerHTML = `${checkCompactSVG}<span>Copied</span>`;
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          copyBtn.innerHTML = original;
+        }, 1600);
+      } catch (err) {
+        copyBtn.classList.remove('copied');
+        copyBtn.classList.add('error');
+        copyBtn.innerHTML = `<span>Copy failed</span>`;
+        setTimeout(() => {
+          copyBtn.classList.remove('error');
+          copyBtn.innerHTML = original;
+        }, 1600);
+      }
+    });
+  }
 }
+

--- a/zepra/RESUELV2/docs/agent_integration_phase0.md
+++ b/zepra/RESUELV2/docs/agent_integration_phase0.md
@@ -1,0 +1,39 @@
+# Phase 0 – Manifest audit & file inventory
+
+## Nanobrowser manifest snapshot
+- **Service worker**: `background.iife.js` runs as a module worker and drives the automation backend. [manifest.json]
+- **Content script**: `content/index.iife.js` injected into all frames on every URL, giving DOM access everywhere. [manifest.json]
+- **Permissions**: Requests `storage`, `scripting`, `tabs`, `activeTab`, `debugger`, `unlimitedStorage`, `webNavigation`, and `sidePanel` for deep automation control. [manifest.json]
+- **Host permissions**: `<all_urls>` enabling cross-site DOM traversal and action execution. [manifest.json]
+- **Side panel & options**: Dedicated `side-panel/index.html` and `options/index.html`, plus `web_accessible_resources` exposing permission pages, JS, CSS, and icons to in-page scripts. [manifest.json]
+
+## Zepra manifest snapshot
+- **Service worker**: `background.js` (non-module) handles Cerebras LLM requests, OCR, identity generation, and UI messaging. [manifest.json]
+- **Content script**: `content.js` runs in all frames at `document_idle` for page augmentation and tool overlays. [manifest.json]
+- **Permissions**: Includes `storage`, `activeTab`, `scripting`, `tabs`, `contextMenus`, `notifications`, clipboard read/write, `browsingData`, and `history`, but lacks Nanobrowser's `debugger`, `webNavigation`, `unlimitedStorage`, and `sidePanel`. [manifest.json]
+- **Host permissions**: Whitelists multiple APIs plus `<all_urls>` for page instrumentation. [manifest.json]
+- **Options UI**: Uses `options.html` via `options_ui` (embedded modal) rather than Nanobrowser's full-page `options_page`. [manifest.json]
+- **Web accessible assets**: Limited to icons and media under `src/media`, so Nanobrowser's permission page/scripts are not yet exposed. [manifest.json]
+
+## Potential conflicts & deltas to resolve
+1. **Automation permissions**: Zepra is missing `debugger`, `webNavigation`, `unlimitedStorage`, and `sidePanel`—all required for Nanobrowser's automation patterns (DOM mirroring, action replay, side panel UI). Need to evaluate necessity and add selectively.
+2. **Side panel availability**: Nanobrowser relies on the MV3 side panel; Zepra currently surfaces tools via popups/modals. Integration will require updating `manifest.json` and `background.js` to register a panel.
+3. **Web-accessible resources**: Voice/permission flows from Nanobrowser expect blanket exposure of JS/CSS. Zepra will need explicit entries for imported modules (e.g., `permission/index.html`, automation bundles) to avoid 404s.
+4. **Options architecture**: Nanobrowser's `options_page` is a standalone React view; Zepra's `options_ui` is simpler. Need a migration strategy (either embed Nanobrowser panels or recreate forms within existing options.)
+5. **All-frames execution**: Both inject across frames, but Nanobrowser's script loads earlier (default `document_idle`). Confirm no race conditions when merging logic into Zepra's `content.js`.
+
+## Working file inventory for next phases
+- **From Nanobrowser**:
+  - `buildDomTree.js` – DOM snapshot/highlight utility for survey parsing.
+  - `background.iife.js` – contains action executors, LLM plumbing, and side panel messaging (needs de-minifying).
+  - `content/index.iife.js` – orchestrates DOM capture and UI overlays (for reference when merging behaviors).
+  - `side-panel/index.html` & bundled JS/CSS – baseline for agent control UI.
+  - `options/index.html` bundle – source for API settings layout.
+  - `permission/index.html` & `permission.js` – microphone access flow to reuse for voice commands.
+- **Within Zepra**:
+  - `background.js` – central hub to receive DOM trees, dispatch LLM plans, and execute actions.
+  - `content.js` – entry point for injecting DOM scanners and agent overlays.
+  - `options.html` / `options.js` – where Cerebras/OpenAI settings and agent toggles will surface.
+  - `src/` (create `agent/` subdirectory) – location for planner, action executor, and shared config modules.
+  - `docs/agent_integration_phase0.md` – this tracker for later reference in LLM prompts.
+

--- a/zepra/RESUELV2/docs/zepra_full_feature_map_ar.txt
+++ b/zepra/RESUELV2/docs/zepra_full_feature_map_ar.txt
@@ -1,0 +1,191 @@
+# خريطة تفصيلية لإضافة Zepra
+
+## 1. نظرة عامة سريعة
+- الامتداد مبني على Manifest V3، وملفه التعريفي موجود فى `manifest.json`. الملف بيحدد إن الـservice worker الرئيسي هو `background.js`، وبيحقن سكربت المحتوى `content.js` ومعاه أداة بناء الـDOM `src/dom/buildDomTree.js` فى كل الصفحات (all_frames=true).
+- كل الواجهات (البوب أب، صفحة الإعدادات، إدارة الهويات، سجل التصفح، نافذة الويب المخصص، نافذة التسجيل) موجودة جوه مجلد `zepra/RESUELV2/` بصيغة HTML + JS مستقلة، وبتسحب نفس ملفات الـCSS المشتركة (زَى `styles.css`, `theme.css`).
+- الأصول الرسومية والصوتية موجودة تحت `icons/` و`src/media/`، وفيه فيديوهات webm بتتكرر فى معظم الواجهات (مثل تأثير الزبرا المتحرك) وصوتيات للنقر/النجاح/التحميل.
+
+## 2. المكونات الخلفية (background.js)
+- **إدارة الجلسة:**
+  - الدالة `checkSession()` بتقيس عمر الجلسة (٣ ساعات) وبتجبر تسجيل الخروج عن طريق `forceLogout()` لما الوقت يخلص أو لو المستخدم مش مسجل دخول.
+  - `updatePopup()` و`updateContextMenu()` بيغيروا الـpopup الافتراضي (بين `login.html` و`popup.html`) وبيظهروا عنصر "Send to Zepra" فى الـcontext menu لما يكون المستخدم داخل.
+  - بيتعامل مع أحداث `onStartup`, `onInstalled`, و`storage.onChanged` علشان يثبت حالة الواجهة بعد إعادة تشغيل المتصفح أو تغيير التخزين.
+- **الاتصال بـCerebras:**
+  - الدالة `callCerebras(prompt)` بتقرأ الإعدادات (الموديل، الـtemperature، الـtimeout، الحد الأقصى للتوكنز، الـbase URL، المفتاح) من `chrome.storage.local` وبتبعت طلب `chat/completions`. فيها حراسة شديدة للأخطاء (429 Rate Limit، 401 Auth، timeout برسالة مخصصة) وبتنضف النص الراجع بفلتر `sanitize`.
+- **أوامر الـSurvey Agent:**
+  - يستورد `src/agent/actions.js` و`src/agent/planner.js`، وبيعرض الرسائل الآتية:
+    - `SURVEY_AGENT_REQUEST_DOM`: يبعت أمر للتاب الحالى يجيب snapshot من `buildDomTree`.
+    - `SURVEY_AGENT_EXECUTE_ACTION` / `SURVEY_AGENT_EXECUTE_BATCH`: يشغل أوامر النقر/الكتابة/الإسكروول على التاب، مع إرجاع حالة واضحة بكل خطأ.
+    - `SURVEY_AGENT_PLAN_NEXT`: يستدعى `surveyAgentPlanner.planNext` علشان يجيب خطوة واحدة من الـLLM.
+    - `SURVEY_AGENT_GET_DEFAULT_PROMPT_TEMPLATE`: بيرجع نص البرومبت الافتراضى علشان صفحة الإعدادات تقدر ترجع الإعدادات لأصلها.
+    - `SURVEY_AGENT_SAVE_HISTORY`: يخزن آخر ٢٥ جلسة استبيان فى `chrome.storage.local` تحت المفتاح `surveyAgentHistory`.
+- **خدمات OCR والتصوير:**
+  - `CAPTURE_AND_OCR`: بياخد Screenshot للتاب، يقص المنطقة المطلوبة بـOffscreenCanvas (أو يرجع للـcontent script لو ما ينفعش) وبعدين يبعت للصوت API `performOCR` (اللى بيستخدم OCR.space).
+  - `CAPTURE_FULL_PAGE_OCR`: بياخد القياسات من الصفحة كلها، يعمل Scroll ويصوّر كل جزء، وبعدين يدمج النصوص.
+- **خدمات الشبكة والـIP:**
+  - `GET_PUBLIC_IP`: بيدور بالتتابع على ipdata.co, ipapi, ipapi.co, وبعدين ipify كملاذ أخير. بيرجع IP، الدولة، المدينة، الـISP، إلخ.
+  - `GET_IP_QUALIFICATION`: بيجلب JSON كامل من ip-score.com ويبعته للواجهة.
+  - `TEST_IPDATA`: بيجرّب مفتاح ipdata من صفحة الإعدادات ويرجع النجاح/الفشل.
+- **المودالات والويب المخصص:**
+  - `OPEN_CUSTOM_WEB` و`OPEN_OR_FOCUS_CUSTOM_WEB`: بيفتح أو يركّز نافذة `custom_web.html`، مع تمرير عنوان الـtab الأصلى، واللينكات اللى هتتفتح جوه النافذة.
+  - `SHOW_NOTIFICATION`: يعمل إشعار `chrome.notifications` بسيط.
+- **المولدات والهوية:**
+  - `GENERATE_IDENTITY` و`GENERATE_COMPANY` بيستخدموا LLM عشان يولدوا بيانات JSON منظمة، مع إجبار على عدم توليد صور.
+  - `GENERATE_FAKE_INFO`: بيستخدم randomuser.me مع كاش ٥ دقايق.
+  - `GENERATE_REAL_ADDRESS`: بيبعت برومبت للـLLM يولد عنوان حقيقى مكوّن من Address1/2 + Zip.
+  - `ANALYZE_FORM`: يبعت HTML فورم للـLLM علشان يرجع Mapping selectors→حقول الهوية.
+- **وظائف مساعدة إضافية:**
+  - `fetchRandomUser`, `performOCR`, `cropImageInWorker`, `arrayBufferToBase64`, `getActiveTabId`، وغيرها مستخدمة فى سكربت المحتوى.
+
+## 3. سكربت المحتوى (content.js)
+- **حالة عامة:**
+  - الكائن `STATE` بيحتفظ بالـoverlay بتاع الـOCR، مودال الإجابات، فقاعة القائمة، آخر إجابة مكتوبة، حالة الهوية، وكمان حالة كاملة للـSurvey Agent (snapshotات، هايلايت، لوج، تشات، إعدادات، إلخ).
+  - بيلود إعدادات الوكيل من `chrome.storage.local` (`useIdentityAnswers`, `deliberateMode`) ويتابع تحديث الـUI لما المستخدم يغيرها من السايد بانل.
+- **جمع الـDOM:**
+  - `collectSurveyDomTree(options)` بيستدعى `buildDomTree`، يخزن النتائج فى كاش، ويضيف بيانات الهوية الجاهزة، قيم الحقول الحالية، ونتائج OCR لو الصور تكررت.
+  - كل Node بيتسجل فى `highlightLookup` عشان ممكن يتركب عليه هايلايت أخضر وقت التنفيذ.
+- **حلقة الوكيل:**
+  - `startSurveyAgentRun(goal, instructions)` بتبنى الحلقة: تجمع DOM → تبعت تاريخ الخطوات للـbackground علشان التخطيط → تنفّذ خطوة → تسجل لوج → تعيد لحد ما توصل `done` أو يحصل خطأ.
+  - فيه throttling ضد التكرار (`repeatPlanCount`, `rateLimitBackoffMs`) علشان أخطاء 429 اللى كانت بتحصل قبل كده.
+  - `logSurveyAgentEvent` بيسجّل رسالة فى التشات (شكل فقاعة Nano) مع الأنواع المختلفة: agent, operator, system, plan, error.
+  - بعد النجاح بيبعت سجل كامل للـbackground (`SURVEY_AGENT_SAVE_HISTORY`) يتضمن وقت البدء/النهاية، الأسئلة اللى اتجاوبت، والسياق.
+- **واجهة الوكيل:**
+  - `createSurveyAgentPanel()` بيعمل سايد بانل منزلق من اليمين بنفس ستايل Nanobrowser: header فيه الحالة (Idle/Running/Error)، زر Start/Stop، Toggle لـIdentity Autofill & Deliberate Mode، ومربع تشات.
+  - الجزء السفلى فيه input للمستخدم، وزرار "Send" بيبعت رسالة للتخطيط وبيبدأ الجلسة تلقائى لو الوكيل متوقف.
+  - الرسائل بتظهر على هيئة فقاعات بأفاتار المستخدم/الوكيل، مع ألوان مختلفة للأخطاء والتحذيرات.
+- **الفقاعة والقائمة الجانبية:**
+  - `createFloatingBubble()` بيضيف دائرة متحركة (فيديو زيبرا + Glow أخضر/أصفر) بتتسحب بالموس، وبتتذكر مكانها فى `chrome.storage.local`.
+  - الضغط عليها يفتح `showBubbleMenu()` (سايدبار بعرض ٣٦٠px بخلفية زجاجية، particles، header فيه زر قفل). العناصر المتاحة:
+    1. OCR Capture (تحديد جزء) & OCR Full Page.
+    2. Write Last Answer (تكتب آخر نتيجة LLM فى الحقل الحالى).
+    3. Survey Agent (يفتح السايد بانل الجديد).
+    4. Clear AI Context (يمسح ذاكرة الأسئلة فى التخزين).
+    5. IP Information, IP Qualification.
+    6. Generate Fake Info, Temp Mail (بيفتح custom web على fakemail).
+    7. Custom Web browser, AI Humanizer.
+    8. Generate Real Address, Generate Company Info.
+    9. Identity Panel (يعرض الهوية النشطة على الصفحة).
+    10. Zebra VPS (قائمة الكلاود سيشنز المختلفة).
+- **مودالات وأدوات UI داخل الصفحة:**
+  - `createRainbowModal()` هو مودال الإجابة الأساسى: خلفية شفافة + card زجاجى، العنوان "Zepra Answer"، وعند تفعيل خيار "عرض التفسير" بيتحول التصميم لشاشتين (Answer + Reason) كل واحدة فى بطاقة بلون مختلف مع زر Copy مستقل.
+    - الفوتر فيه أزرار: Write Here (يكتب فى الحقل النشط)، Write All (يكتب على كل الحقول اللى متلائمة)، Copy، AI Humanizer (يفتح موقع الكتابة البشرية)، Use Custom Prompt (يختار برومبت محفوظ).
+  - `showOverlayAndSelect()` بيضيف overlay شفاف علشان المستخدم يسحب مستطيل لـOCR، وبعد ما يختار بيرجع الإحداثيات.
+  - `showCleanIPQualificationModal(data)` بيبنى نافذة card بدون border خارجية، فيها دائرة خطر متدرجة، Checklist من عناصر مثل (Blacklist, VPN, Proxy, Tor, Cloud Provider)، وثلاث كروت للـIP/Location/ISP.
+  - `showIPModal(info)` مودال تفاعلى يعرض الـIP، Location، Postal، Timezone، ISP مع زر Copy بيتحول `Copied!`.
+  - `showFakeInfoModal()`: مودال ضخم فيه Tabs للبيانات الشخصية، التواصل، العنوان، الشركة. يتيح اختيار الجنس والـNationality، ويعرض معلومات randomuser. فيه زر Copy لكل عنصر.
+  - `showRealAddressModal()`: مودال بسيط يسأل عن Country/State/City، يجيب عنوان حقيقى من الـLLM، يوزع البيانات فى Inputs مع زر Copy.
+  - `showCompanyInfoModal()`: card Business فيها اسم، صناعة، حجم الشركة، الإيراد، موقع إلكترونى، عنوان، مع زر Copy.
+  - `showIdentityPanel()` يعرض الهوية النشطة فى card فى الصفحة نفسها (بدون الرجوع لصفحة identities).
+  - `showZebraVPSModal()` فيه تلات كروت (Windows trial, Android 6H, Android Pixel) وعند الضغط بيفتح نافذة custom web باللينكات المناسبة.
+  - مودال Temp Mail بيفتح custom web بنفس الشكل.
+- **التفاعل مع الحقول:**
+  - `typeIntoFocusedElement(text, options)` بيكتب حرف حرف بسرعة شبه بشرية (fast/normal/slow) وبيطلق Events (keydown, input, keyup, change) عشان الصفحات تلتقط القيمة.
+  - `fillForm(form)` و`analyzeFormWithAI(form)` بيملاوا الفورم بالهوية الحالية أو بالـmapping الراجع من الـLLM.
+  - `detectField(el)` بيحاول يتعرف على نوع الحقل من خلال الـname/id/placeholder ويطابقه مع مفاتيح الهوية (email, fullName, address...)
+  - فيه مراقبة مستمرة لـfocus علشان يخزن `STATE.lastFocused` للكتابة التلقائية.
+- **رسائل من الخلفية:**
+  - بيسمع `TYPE_TEXT`, `START_OCR_SELECTION`, `CROP_IMAGE_IN_CONTENT`, `SHOW_ZEPRA_MODAL`, `SCROLL_TO`, `GET_PAGE_DIMENSIONS`, بجانب رسائل الوكيل.
+  - فيه أمر `PING` بيرجع {ok:true} علشان يتأكد إن المحتوى محمل.
+- **Features إضافية:**
+  - تخزين آخر إجابة فى `STATE.currentAnswer` علشان تقدر تستخدم "Write Last Answer" حتى بعد إغلاق المودال.
+  - لما تستخرج OCR، النتيجة بتتخزن فى preview داخل البوب أب.
+  - لو المستخدم فعل خيار "Show Reasoning" من الإعدادات، المودال هيعرض reasoning Pane تلقائى وتتحول أزرار النسخ.
+
+## 4. واجهة تسجيل الدخول (login.html / login.js)
+- خلفية عبارة عن فيديو متغير (`zepra.webm` أو `carry.webm`) داخل عنصر `headerWrap`، بيتبدل بإنسياب عند نجاح/فشل التسجيل (`switchHeader`).
+- الفورم فيه حقول Email/Password، زر "Login" بصوت Click، ورسالة خطأ/نجاح تحت الفورم.
+- صوت النجاح `success.mp3` بيتشغل مع رسالة "Logged in successfully!" وبعد ٠.٨ ثانية يحول المستخدم للبوب أب.
+- لو فيه `logoutMsg` مخزنة فى `storage.local` بتظهر باللون الأحمر مع بداية الصفحة.
+- `performLogin` بيتعامل مباشرة مع Firebase REST API (`identitytoolkit`) وبيخزن `loggedIn`, `userEmail`, `loginTime` فى التخزين المحلى.
+
+## 5. البوب أب (popup.html / popup.js)
+- التصميم العام: خلفية داكنة مع فيديوهات صغيرة على الأزرار (class `icon-btn`)، وكل زر بيشغل `btn_hover.webm` على hover/click.
+- الجزء العلوى بيعرض:
+  - اسم البريد المسجل (`userEmail`).
+  - عداد تنازلى للوقت المتبقى فى الجلسة (فورمات hh:mm:ss) مع تحديث كل ثانية.
+  - زر Logout بيرجع المستخدم لصفحة الدخول بعد مسح التخزين.
+- **أزرار الأنماط:** سبعة أزرار (Open-ended, MCQ, Scale, Yes/No, Auto, OCR, Translate) بتظهر ثلاثة فى الصفحة الواحدة، مع أسهم Prev/Next للتبديل بينهم (كل صفحة ٣ عناصر).
+- زر "Auto" بيختار النوع تلقائى. لما المستخدم يضغط زر Mode:
+  1. يجمع النص المختار من الصفحة أو من OCR.
+  2. يبنى برومبت حسب النوع (`buildPrompt`).
+  3. يعرض حالة "Generating answer..." أو "🧠 Thinking..." لو الموديل فيه كلمة Thinking.
+  4. يستدعى `CEREBRAS_GENERATE` ويرجع النتيجة لمودال الإجابة.
+- زر `btnOCR` بيشغل Overlay الاختيار، يبعته للـbackground علشان OCR، ويحط النص فى الـtextarea `preview`.
+- `btnTranslate` حالياً Placeholder برسالة "Coming soon".
+- أزرار إضافية:
+  - `btnCopy` ينسخ آخر إجابة من preview.
+  - `btnWrite` يكتب الإجابة الحالية فى الصفحة بعد عد تنازلى ٣ ثوانى.
+  - `btnCustomPrompt` و`btnUseLastPrompt` بيتعاملوا مع البرومبتات المحفوظة (بيفتحوا مودال اختيار).
+- Navigation Links فى أسفل البوب أب:
+  - `navCustom`: يفتح نافذة custom web.
+  - `navIdent`: يفتح صفحة إدارة الهوية.
+  - `navOptions`: يفتح صفحة الإعدادات فى تاب جديد.
+  - `openActivityLog`: يحول للموقع `history.html` جوه نفس نافذة الامتداد.
+- `handleMode('auto')` وغيره بيحفظوا آخر سؤال/إجابة فى `chrome.storage.local` تحت `contextQA` لغاية ١٠ عناصر.
+
+## 6. صفحة الإعدادات (options.html / options.js)
+- الواجهة عبارة عن Modal على الشاشة كلها (blur + border بنفسجى) مع:
+  - Header فيه عنوان "Zepra Control Center"، زر إغلاق، وIndicator متحرك على الناف بار الجانبى.
+  - Sidebar فيه روابط لأقسام: Theme & API، LLM Settings، Typing & OCR، Custom Prompts، Custom Sites، إلخ. لكل رابط أيقونة SVG ونص.
+  - الIndicator `nav-indicator` بيتحرك بسلاسة حسب القسم المختار.
+- الـbody عبارة عن مساحة محتوى قابلة للتمرير لكل قسم، فيها عناصر فورم Styled (Toggle، Select، Inputs بألوان نيون).
+- زرار حفظ التعديلات عبارة عن شريط سفلى (`saveBar`) بيظهر لما يحصل تغييرات. فيه أزرار Reset و Save.
+- **إعدادات الـLLM:**
+  - حقول لمفتاح Cerebras، الموديل (Dropdown)، الـBase URL، Timeout بالثوانى، Temperature، Max Tokens، مع زر Reset Template بيجيب البرومبت الافتراضى من الخلفية.
+  - فى قسم "LLM Planner Template" فيه textarea كبير يعرض البرومبت الفعلى المستخدم فى الوكيل، مع زر لإرجاعه للـdefault.
+- **إعدادات أخرى:**
+  - `typingSpeed` (fast/normal/slow)، `showReasoning` toggle، لغة التفسير، لغة الـOCR.
+  - `customWebSize` (width/height) لحفظ مقاس نافذة الويب المخصص.
+  - `primaryColor` بتغير اللون الأساسى (بينعكس فوراً على المتغير `--accent`).
+  - خانات لحفظ مفتاح OCR.space، مفتاح ipdata، مع زر "Test" بيستدعى `TEST_IPDATA` ويعرض Toast نجاح/فشل.
+- **إدارة البرومبتات:**
+  - جدول يظهر الاسم، التاجز، الهوت كى، وزر Edit/Delete لكل برومبت.
+  - فورم لإنشاء/تعديل البرومبت مع حقول الاسم، التاجز، الهوت كى، النص.
+- **المواقع المخصصة:**
+  - قائمة بالمواقع، مع حقول لإضافة موقع جديد (اسم + URL)، وزر Add. بتتخزن فى `chrome.storage.local.customSites`.
+- الصفحة بتستخدم أصوات النقر، Animations، Overlay تحميل شفاف يظهر أثناء حفظ التعديلات.
+
+## 7. إدارة الهوية (identities.html / identities.js)
+- الواجهة Grid من الكروت، كل كارت يعرض فيديو فى الخلفية، Badge "Active"، الاسم، البريد، وزرار Activate/Deactivate، Edit، Delete.
+- زر "Create Identity" يفتح Panel جانبى فيه فورم لكل حقول الهوية (الاسم، البريد، التليفون، العنوان، بيانات الشركة...).
+- زر "AI Identity" يفتح نفس البانل بس فى وضع AI: يعرض textarea للبرومبت وزر Generate. أثناء الانتظار بيظهر Skeleton Animated (`aiSkeleton`).
+- بعد ما الـLLM يرجع JSON بيتحول أوتوماتيكياً للفورم اليدوى علشان المستخدم يعدل قبل الحفظ.
+- الهوية النشطة بتتخزن فى `chrome.storage.local.activeIdentityId`، وكل الهويات فى `identities`.
+
+## 8. نافذة الويب المخصص (custom_web.html / custom_web.js)
+- عبارة عن واجهة فيها Dropdown للمواقع المحفوظة، زر Toggle لإخفاء/إظهار القائمة، أزرار "Write Here" و"Clear Data"، ومساحة `iframe` بتبدل بين المواقع.
+- عند الضغط على "Write Here" بيسحب التحديد من الـiframe أو يحاول يعمل Copy ويبعته للتاب الأصلى عشان يتكتب بنفس سرعات الكتابة فى الإعدادات.
+- "Clear Data" بيمسح الكوكيز والـlocalStorage للموقع الحالى باستخدام `chrome.browsingData.remove`.
+- بتحفظ مقاس النافذة فى `chrome.storage.local.customWebSize` مع كل Resize/Unload.
+- بيستورد المواقع الافتراضية (Easemate Chat، Whoer، Bypass AI Humanizer، Prinsh Notepad) ولو فيه URLs جاية من البوب أب بيتضيفوا مؤقتاً.
+
+## 9. سجل التصفح (history.html / history.js)
+- يعرض آخر ١٠٠٠ عنصر من `chrome.history.search` فى شكل Cards بسيطة فيها العنوان، الرابط، وزراير:
+  - Open ↗ (فتح فى تاب جديد)
+  - Copy 📋 (نسخ الرابط)
+  - Add ➕ (إضافة للمواقع المخصصة فى custom web)
+- فى أعلى الصفحة حقل بحث لحصر النتائج.
+
+## 10. ملفات إضافية
+- **theme.js:** بيطبق اللون الأساسى المخزن على المتغير `--accent` وبيوفر وظيفة `showLoadingIndicator` (فيديو webm صغير) تتستخدم فى صفحات تانية.
+- **youtube-dubbing.js:** سكربت محتوى مخصص ليوتيوب، بيضيف زر دائرى على شريط أدوات الفيديو، بيفتح مودال Floating فيه اختيار لغة (من قائمة iFlytek) وتفاصيل معالجة الصوت. فيه نظام Drag للزر، وتحكم فى الصوت الأصلى للفيديو.
+- **styles.css / theme.css:** بيثبتوا الثيم الداكن، الخطوط، تأثيرات الخلفية الشبكية، ألوان الأخضر والوردى المتوهجة المستخدمة فى كل الواجهات.
+- **docs/agent_integration_phase0.md:** مستند سابق بيوثق مقارنة Zepra مع Nanobrowser قبل الدمج.
+
+## 11. تجربة المستخدم العامة
+- كل النوافذ بتشتغل بنفس التيمة: خلفيات زجاجية، بوردارات متوهجة، فيديوهات looping، وحركات hover.
+- فى البوب أب والخيارات، فيه صوت click لكل زر (موجود فى `src/media/click.mp3`).
+- العد التنازلى قبل الكتابة بيدي المستخدم فرصة يركز على الحقل الصحيح.
+- الفقاعة العائمة بتضمن الوصول لكل الأدوات من الصفحة نفسها بدون الرجوع للبوب أب.
+- الـSurvey Agent بقى مكامل بالكامل: تشات زى Nanobrowser، إمكانية تشغيل تلقائى أو التعلم الذكى باستخدام الهوية والـOCR، وتسجيل النتائج فى التاريخ.
+
+## 12. الصلاحيات والاعتمادات
+- الصلاحيات الرئيسية: `activeTab`, `scripting`, `tabs`, `contextMenus`, `notifications`, `clipboardRead`, `clipboardWrite`, `history`, `browsingData`.
+- `host_permissions` مفتوحة لـ `<all_urls>` علشان الوكيل والـOCR يشتغلوا جوه أى إطار، بالإضافة لـAPIs محددة (Cerebras، OCR.space، ipdata، ip-score، mail.tm، randomuser...).
+- مصادر الويب المتاحة (`web_accessible_resources`) بتضمن الأيقونات، ملفات الميديا، وملفات الـDOM Snapshot علشان الإطارات الداخلية تقدر تستخدمها.
+
+## 13. أفكار جاهزة للتكامل المستقبلى
+- الواجهة الحالية بتدعم التعديل السريع على الثيم، فممكن تستغل `primaryColor` لتوحيد ألوان السايد بانل بتاع الوكيل مع باقى الواجهات.
+- بما إن الـSurvey Agent بيسجل تاريخه فى `surveyAgentHistory`، ممكن تعمل صفحة عرض داخل options أو history لعرض الجلسات السابقة.
+- الـOCR والهوية والـIP متاحين بالفعل، فدمجهم مع خطوات الوكيل (مثلاً إظهار تحذير لو الـIP مش مؤهل قبل بدء التشغيل) هيكون بسيط لأن الخلفية مجهزة برسائل واضحة.
+

--- a/zepra/RESUELV2/manifest.json
+++ b/zepra/RESUELV2/manifest.json
@@ -38,7 +38,7 @@
     "history"
   ],
   "web_accessible_resources": [{
-    "resources": ["icons/*", "src/media/*"],
+    "resources": ["icons/*", "src/media/*", "src/dom/*"],
     "matches": ["<all_urls>"]
   }],
   "host_permissions": [
@@ -64,7 +64,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content.js"],
+      "js": ["src/dom/buildDomTree.js", "content.js"],
       "run_at": "document_idle",
       "all_frames": true
     }

--- a/zepra/RESUELV2/options.html
+++ b/zepra/RESUELV2/options.html
@@ -290,6 +290,13 @@
       background: rgba(0, 0, 0, 0.6);
     }
 
+    .form-hint {
+      font-size: 12px;
+      color: #94a3b8;
+      line-height: 1.5;
+      margin-top: 8px;
+    }
+
     /* Toggle switch */
     .toggle-switch {
       position: relative;
@@ -778,6 +785,29 @@
                 </select>
               </div>
             </div>
+
+            <div class="settings-card">
+              <h3 class="card-title">LLM Advanced Settings</h3>
+              <div class="form-group">
+                <label class="form-label">Cerebras Base URL</label>
+                <input type="text" id="cerebrasBaseUrl" class="form-input" placeholder="https://api.cerebras.ai/v1">
+                <p class="form-hint">The agent automatically appends <code>/chat/completions</code> if needed.</p>
+              </div>
+              <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px;">
+                <div class="form-group" style="margin-bottom: 0;">
+                  <label class="form-label">Request Timeout (seconds)</label>
+                  <input type="number" min="5" max="180" step="1" id="cerebrasTimeout" class="form-input" placeholder="60">
+                </div>
+                <div class="form-group" style="margin-bottom: 0;">
+                  <label class="form-label">Temperature</label>
+                  <input type="number" min="0" max="2" step="0.1" id="cerebrasTemperature" class="form-input" placeholder="0.2">
+                </div>
+                <div class="form-group" style="margin-bottom: 0;">
+                  <label class="form-label">Max Completion Tokens</label>
+                  <input type="number" min="16" max="4096" step="1" id="cerebrasMaxTokens" class="form-input" placeholder="1024">
+                </div>
+              </div>
+            </div>
           </div>
 
           <!-- Reasoning & OCR Section -->
@@ -805,6 +835,21 @@
                   <option value="eng" selected>English (eng)</option>
                   <option value="ara">Arabic (ara)</option>
                 </select>
+              </div>
+            </div>
+
+            <div class="settings-card">
+              <h3 class="card-title">Planner Prompt Template</h3>
+              <div class="form-group">
+                <label class="form-label" for="plannerPromptTemplate">Template</label>
+                <textarea id="plannerPromptTemplate" class="form-input" rows="10" spellcheck="false"></textarea>
+                <p class="form-hint">
+                  Placeholders: <code>{{GOAL_SECTION}}</code>, <code>{{ALLOWED_ACTIONS}}</code>, <code>{{FORMAT_GUIDE}}</code>,
+                  <code>{{RULES}}</code>, <code>{{DOM_SUMMARY}}</code>, <code>{{HISTORY}}</code>, <code>{{EXTRA_INSTRUCTIONS}}</code>.
+                </p>
+              </div>
+              <div style="display: flex; justify-content: flex-end; gap: 12px;">
+                <button id="resetPlannerTemplate" type="button" class="btn btn-reset">Reset to Default</button>
               </div>
             </div>
           </div>

--- a/zepra/RESUELV2/options.js
+++ b/zepra/RESUELV2/options.js
@@ -1,11 +1,44 @@
 // Modern Options.js - Complete Rewrite
+
+const LOCAL_DEFAULT_PLANNER_TEMPLATE = [
+  "You are Zepra's survey automation planner. You see a DOM snapshot of a survey page and a short history of executed actions.",
+  'Plan ONLY the next action needed to progress towards completing the survey.',
+  '',
+  '{{GOAL_SECTION}}',
+  '',
+  'Allowed action types:',
+  '{{ALLOWED_ACTIONS}}',
+  '',
+  'Response format:',
+  '{{FORMAT_GUIDE}}',
+  '',
+  'Rules:',
+  '{{RULES}}',
+  '',
+  'DOM summary:',
+  '{{DOM_SUMMARY}}',
+  '',
+  'Recent history:',
+  '{{HISTORY}}',
+  '',
+  'Respond with the JSON schema shown above.{{EXTRA_INSTRUCTIONS}}'
+].join('\n');
+
+const DEFAULT_AGENT_SETTINGS = {
+  baseUrl: 'https://api.cerebras.ai/v1',
+  timeoutSeconds: 60,
+  temperature: 0.2,
+  maxTokens: 1024
+};
+
 class ModernOptionsManager {
   constructor() {
     this.currentSection = 'theme-api';
     this.hasUnsavedChanges = false;
     this.originalValues = {};
     this.editingPromptId = null;
-    
+    this.defaultPlannerTemplate = null;
+
     this.initializeElements();
     this.bindEvents();
     this.loadSettings();
@@ -31,6 +64,10 @@ class ModernOptionsManager {
       primaryColor: document.getElementById('primaryColor'),
       cerebrasKey: document.getElementById('cerebrasKey'),
       cerebrasModel: document.getElementById('cerebrasModel'),
+      cerebrasBaseUrl: document.getElementById('cerebrasBaseUrl'),
+      cerebrasTimeout: document.getElementById('cerebrasTimeout'),
+      cerebrasTemperature: document.getElementById('cerebrasTemperature'),
+      cerebrasMaxTokens: document.getElementById('cerebrasMaxTokens'),
       ocrKey: document.getElementById('ocrKey'),
       ipdataKey: document.getElementById('ipdataKey'),
       testIpdata: document.getElementById('testIpdata'),
@@ -38,9 +75,11 @@ class ModernOptionsManager {
       showReasoning: document.getElementById('showReasoning'),
       reasonLang: document.getElementById('reasonLang'),
       ocrLang: document.getElementById('ocrLang'),
+      plannerPromptTemplate: document.getElementById('plannerPromptTemplate'),
+      resetPlannerTemplate: document.getElementById('resetPlannerTemplate'),
       webWidth: document.getElementById('webWidth'),
       webHeight: document.getElementById('webHeight'),
-      
+
       // Prompts
       promptForm: document.getElementById('promptForm'),
       promptName: document.getElementById('promptName'),
@@ -81,7 +120,8 @@ class ModernOptionsManager {
     // Specific actions
     this.elements.testIpdata?.addEventListener('click', () => this.testIpdataConnection());
     this.elements.primaryColor?.addEventListener('input', (e) => this.updateThemeColor(e.target.value));
-    
+    this.elements.resetPlannerTemplate?.addEventListener('click', () => this.resetPlannerTemplate());
+
     // Prompt management
     this.elements.savePrompt?.addEventListener('click', () => this.savePrompt());
     this.elements.cancelPrompt?.addEventListener('click', () => this.cancelPromptEdit());
@@ -96,14 +136,28 @@ class ModernOptionsManager {
   async loadSettings() {
     try {
       const settings = await chrome.storage.local.get([
-        'cerebrasApiKey', 'cerebrasModel', 'ocrApiKey', 'ipdataApiKey',
+        'cerebrasApiKey', 'cerebrasModel', 'cerebrasBaseUrl', 'cerebrasTimeoutMs',
+        'cerebrasTemperature', 'cerebrasMaxTokens', 'ocrApiKey', 'ipdataApiKey',
         'typingSpeed', 'ocrLang', 'customWebSize', 'primaryColor',
-        'showReasoning', 'reasonLang'
+        'showReasoning', 'reasonLang', 'surveyPlannerPromptTemplate'
       ]);
 
       // Populate form fields
       if (this.elements.cerebrasKey) this.elements.cerebrasKey.value = settings.cerebrasApiKey || '';
       if (this.elements.cerebrasModel) this.elements.cerebrasModel.value = settings.cerebrasModel || 'gpt-oss-120b';
+      if (this.elements.cerebrasBaseUrl) this.elements.cerebrasBaseUrl.value = settings.cerebrasBaseUrl || DEFAULT_AGENT_SETTINGS.baseUrl;
+      if (this.elements.cerebrasTimeout) {
+        const timeoutMs = Number.isFinite(settings.cerebrasTimeoutMs) ? settings.cerebrasTimeoutMs : DEFAULT_AGENT_SETTINGS.timeoutSeconds * 1000;
+        this.elements.cerebrasTimeout.value = Math.round(timeoutMs / 1000);
+      }
+      if (this.elements.cerebrasTemperature) {
+        const temp = Number.isFinite(settings.cerebrasTemperature) ? settings.cerebrasTemperature : DEFAULT_AGENT_SETTINGS.temperature;
+        this.elements.cerebrasTemperature.value = temp;
+      }
+      if (this.elements.cerebrasMaxTokens) {
+        const max = Number.isFinite(settings.cerebrasMaxTokens) ? settings.cerebrasMaxTokens : DEFAULT_AGENT_SETTINGS.maxTokens;
+        this.elements.cerebrasMaxTokens.value = max;
+      }
       if (this.elements.ocrKey) this.elements.ocrKey.value = settings.ocrApiKey || '';
       if (this.elements.ipdataKey) this.elements.ipdataKey.value = settings.ipdataApiKey || '';
       if (this.elements.typingSpeed) this.elements.typingSpeed.value = settings.typingSpeed || 'normal';
@@ -113,6 +167,12 @@ class ModernOptionsManager {
       if (this.elements.showReasoning) this.elements.showReasoning.checked = settings.showReasoning || false;
       if (this.elements.reasonLang) this.elements.reasonLang.value = settings.reasonLang || '';
       if (this.elements.primaryColor) this.elements.primaryColor.value = settings.primaryColor || '#39ff14';
+      if (this.elements.plannerPromptTemplate) {
+        const template = typeof settings.surveyPlannerPromptTemplate === 'string'
+          ? settings.surveyPlannerPromptTemplate
+          : await this.fetchDefaultPlannerTemplate();
+        this.elements.plannerPromptTemplate.value = template;
+      }
 
       // Apply theme
       if (settings.primaryColor) {
@@ -121,7 +181,7 @@ class ModernOptionsManager {
 
       // Store original values for change tracking
       this.storeOriginalValues();
-      
+
       // Load additional data
       await this.loadPrompts();
       await this.loadSites();
@@ -136,6 +196,10 @@ class ModernOptionsManager {
     this.originalValues = {
       cerebrasKey: this.elements.cerebrasKey?.value || '',
       cerebrasModel: this.elements.cerebrasModel?.value || '',
+      cerebrasBaseUrl: this.elements.cerebrasBaseUrl?.value || '',
+      cerebrasTimeout: this.elements.cerebrasTimeout?.value || '',
+      cerebrasTemperature: this.elements.cerebrasTemperature?.value || '',
+      cerebrasMaxTokens: this.elements.cerebrasMaxTokens?.value || '',
       ocrKey: this.elements.ocrKey?.value || '',
       ipdataKey: this.elements.ipdataKey?.value || '',
       typingSpeed: this.elements.typingSpeed?.value || '',
@@ -144,21 +208,23 @@ class ModernOptionsManager {
       webHeight: this.elements.webHeight?.value || '',
       showReasoning: this.elements.showReasoning?.checked || false,
       reasonLang: this.elements.reasonLang?.value || '',
-      primaryColor: this.elements.primaryColor?.value || ''
+      primaryColor: this.elements.primaryColor?.value || '',
+      plannerPromptTemplate: this.elements.plannerPromptTemplate?.value || ''
     };
   }
 
   trackFormChanges() {
     const formElements = [
-      this.elements.cerebrasKey, this.elements.cerebrasModel, this.elements.ocrKey,
-      this.elements.ipdataKey, this.elements.typingSpeed, this.elements.ocrLang,
+      this.elements.cerebrasKey, this.elements.cerebrasModel, this.elements.cerebrasBaseUrl,
+      this.elements.cerebrasTimeout, this.elements.cerebrasTemperature, this.elements.cerebrasMaxTokens,
+      this.elements.ocrKey, this.elements.ipdataKey, this.elements.typingSpeed, this.elements.ocrLang,
       this.elements.webWidth, this.elements.webHeight, this.elements.showReasoning,
-      this.elements.reasonLang, this.elements.primaryColor
+      this.elements.reasonLang, this.elements.primaryColor, this.elements.plannerPromptTemplate
     ];
 
     formElements.forEach(element => {
       if (!element) return;
-      
+
       const eventType = element.type === 'checkbox' ? 'change' : 'input';
       element.addEventListener(eventType, () => this.checkForChanges());
     });
@@ -168,6 +234,10 @@ class ModernOptionsManager {
     const currentValues = {
       cerebrasKey: this.elements.cerebrasKey?.value || '',
       cerebrasModel: this.elements.cerebrasModel?.value || '',
+      cerebrasBaseUrl: this.elements.cerebrasBaseUrl?.value || '',
+      cerebrasTimeout: this.elements.cerebrasTimeout?.value || '',
+      cerebrasTemperature: this.elements.cerebrasTemperature?.value || '',
+      cerebrasMaxTokens: this.elements.cerebrasMaxTokens?.value || '',
       ocrKey: this.elements.ocrKey?.value || '',
       ipdataKey: this.elements.ipdataKey?.value || '',
       typingSpeed: this.elements.typingSpeed?.value || '',
@@ -176,10 +246,11 @@ class ModernOptionsManager {
       webHeight: this.elements.webHeight?.value || '',
       showReasoning: this.elements.showReasoning?.checked || false,
       reasonLang: this.elements.reasonLang?.value || '',
-      primaryColor: this.elements.primaryColor?.value || ''
+      primaryColor: this.elements.primaryColor?.value || '',
+      plannerPromptTemplate: this.elements.plannerPromptTemplate?.value || ''
     };
 
-    const hasChanges = Object.keys(currentValues).some(key => 
+    const hasChanges = Object.keys(currentValues).some(key =>
       currentValues[key] !== this.originalValues[key]
     );
 
@@ -293,9 +364,26 @@ class ModernOptionsManager {
 
   async saveAllChanges() {
     try {
+      const timeoutSeconds = parseInt(this.elements.cerebrasTimeout?.value, 10);
+      const timeoutMs = Number.isFinite(timeoutSeconds) && timeoutSeconds > 0
+        ? timeoutSeconds * 1000
+        : DEFAULT_AGENT_SETTINGS.timeoutSeconds * 1000;
+      const rawTemperature = parseFloat(this.elements.cerebrasTemperature?.value);
+      const temperature = Number.isFinite(rawTemperature)
+        ? Math.min(Math.max(rawTemperature, 0), 2)
+        : DEFAULT_AGENT_SETTINGS.temperature;
+      const rawMaxTokens = parseInt(this.elements.cerebrasMaxTokens?.value, 10);
+      const maxTokens = Number.isFinite(rawMaxTokens) && rawMaxTokens > 0
+        ? rawMaxTokens
+        : DEFAULT_AGENT_SETTINGS.maxTokens;
+
       const settings = {
         cerebrasApiKey: this.elements.cerebrasKey?.value?.trim() || '',
         cerebrasModel: this.elements.cerebrasModel?.value || 'gpt-oss-120b',
+        cerebrasBaseUrl: this.elements.cerebrasBaseUrl?.value?.trim() || DEFAULT_AGENT_SETTINGS.baseUrl,
+        cerebrasTimeoutMs: timeoutMs,
+        cerebrasTemperature: temperature,
+        cerebrasMaxTokens: maxTokens,
         ocrApiKey: this.elements.ocrKey?.value?.trim() || '',
         ipdataApiKey: this.elements.ipdataKey?.value?.trim() || '',
         typingSpeed: this.elements.typingSpeed?.value || 'normal',
@@ -306,11 +394,12 @@ class ModernOptionsManager {
         },
         primaryColor: this.elements.primaryColor?.value || '#39ff14',
         showReasoning: this.elements.showReasoning?.checked || false,
-        reasonLang: this.elements.reasonLang?.value?.trim() || ''
+        reasonLang: this.elements.reasonLang?.value?.trim() || '',
+        surveyPlannerPromptTemplate: this.elements.plannerPromptTemplate?.value || ''
       };
 
       await chrome.storage.local.set(settings);
-      
+
       // Update original values
       this.storeOriginalValues();
       this.hasUnsavedChanges = false;
@@ -329,7 +418,7 @@ class ModernOptionsManager {
     Object.keys(this.originalValues).forEach(key => {
       const element = this.elements[key];
       if (!element) return;
-      
+
       if (element.type === 'checkbox') {
         element.checked = this.originalValues[key];
       } else {
@@ -339,10 +428,36 @@ class ModernOptionsManager {
 
     // Update theme
     this.updateThemeColor(this.originalValues.primaryColor);
-    
+
     this.hasUnsavedChanges = false;
     this.toggleSaveBar(false);
     this.showStatus('Changes reverted', 'info');
+  }
+
+  async fetchDefaultPlannerTemplate() {
+    if (this.defaultPlannerTemplate) {
+      return this.defaultPlannerTemplate;
+    }
+    try {
+      const response = await chrome.runtime.sendMessage({ type: 'SURVEY_AGENT_GET_DEFAULT_PROMPT_TEMPLATE' });
+      const template = typeof response?.template === 'string' && response.template.trim().length
+        ? response.template
+        : LOCAL_DEFAULT_PLANNER_TEMPLATE;
+      this.defaultPlannerTemplate = template;
+      return template;
+    } catch (error) {
+      console.warn('Failed to fetch default planner template, using local fallback.', error);
+      this.defaultPlannerTemplate = LOCAL_DEFAULT_PLANNER_TEMPLATE;
+      return this.defaultPlannerTemplate;
+    }
+  }
+
+  async resetPlannerTemplate() {
+    if (!this.elements.plannerPromptTemplate) return;
+    const template = await this.fetchDefaultPlannerTemplate();
+    this.elements.plannerPromptTemplate.value = template;
+    this.checkForChanges();
+    this.showStatus('Planner template reset to default', 'info');
   }
 
   // Prompt Management

--- a/zepra/RESUELV2/src/agent/actions.js
+++ b/zepra/RESUELV2/src/agent/actions.js
@@ -1,0 +1,403 @@
+/*
+ * Survey Agent action executors
+ * Ported from Nanobrowser's background automation routines into reusable
+ * helpers that talk to Zepra's content script.
+ */
+(function attachSurveyAgentActions(globalThis) {
+  const STATUS = {
+    OK: 'ok',
+    FAIL: 'fail',
+  };
+
+  const MESSAGE_CODES = {
+    CLICK: {
+      START: 'act_click_start',
+      OK: 'act_click_ok',
+      FAIL: 'act_errors_elementNotExist',
+    },
+    INPUT: {
+      START: 'act_inputText_start',
+      OK: 'act_inputText_ok',
+      FAIL: 'act_errors_elementNotExist',
+    },
+    SELECT: {
+      START: 'act_selectDropdownOption_start',
+      OK: 'act_selectDropdownOption_ok',
+      FAIL: 'act_selectDropdownOption_failed',
+    },
+    SCROLL: {
+      START: 'act_scroll_start',
+      OK: 'act_scroll_ok',
+      FAIL: 'act_scroll_failed',
+    },
+    NAVIGATE: {
+      START: 'act_goToUrl_start',
+      OK: 'act_goToUrl_ok',
+      FAIL: 'act_goToUrl_failed',
+    },
+    BACK: {
+      START: 'act_goBack_start',
+      OK: 'act_goBack_ok',
+      FAIL: 'act_goBack_failed',
+    },
+    FORWARD: {
+      START: 'act_goForward_start',
+      OK: 'act_goForward_ok',
+      FAIL: 'act_goForward_failed',
+    },
+    RELOAD: {
+      START: 'act_reload_start',
+      OK: 'act_reload_ok',
+      FAIL: 'act_reload_failed',
+    },
+    WAIT: {
+      START: 'act_wait_start',
+      OK: 'act_wait_ok',
+      FAIL: 'act_wait_failed',
+    },
+    STATUS: {
+      START: 'act_status_start',
+      OK: 'act_status_ok',
+      FAIL: 'act_status_failed',
+    },
+    IP_INFO: {
+      START: 'act_ipInfo_start',
+      OK: 'act_ipInfo_ok',
+      FAIL: 'act_ipInfo_failed',
+    },
+    IP_CHECK: {
+      START: 'act_ipCheck_start',
+      OK: 'act_ipCheck_ok',
+      FAIL: 'act_ipCheck_failed',
+    },
+    CUSTOM_OPEN: {
+      START: 'act_customOpen_start',
+      OK: 'act_customOpen_ok',
+      FAIL: 'act_customOpen_failed',
+    },
+    NOTE_SAVE: {
+      START: 'act_noteSave_start',
+      OK: 'act_noteSave_ok',
+      FAIL: 'act_noteSave_failed',
+    },
+    OPEN_TAB: {
+      START: 'act_openTab_start',
+      OK: 'act_openTab_ok',
+      FAIL: 'act_openTab_failed',
+    },
+  };
+
+  function buildOk(code, details = {}, meta = {}) {
+    return { ok: true, status: STATUS.OK, code, details, meta };
+  }
+
+  function buildFail(code, error, details = {}, meta = {}) {
+    return { ok: false, status: STATUS.FAIL, code, error: error?.message || String(error), details, meta };
+  }
+
+  async function ensureContentScript(tabId) {
+    if (!tabId) throw new Error('NO_TAB_ID');
+    try {
+      await chrome.tabs.sendMessage(tabId, { type: 'PING' });
+      return;
+    } catch (err) {
+      try {
+        await chrome.scripting.executeScript({ target: { tabId }, files: ['content.js'] });
+      } catch (injectErr) {
+        throw err instanceof Error ? err : injectErr || err;
+      }
+    }
+  }
+
+  async function sendAction(tabId, actionPayload) {
+    await ensureContentScript(tabId);
+    const response = await chrome.tabs.sendMessage(tabId, {
+      type: 'SURVEY_AGENT_EXECUTE_ACTION',
+      action: actionPayload,
+    });
+    if (!response) throw new Error('NO_RESPONSE');
+    if (!response.ok) {
+      const err = new Error(response.error || 'ACTION_FAILED');
+      err.code = response.code;
+      err.details = response.details;
+      throw err;
+    }
+    return response;
+  }
+
+  async function click(tabId, step = {}) {
+    const { locator = {}, intent, scrollIntoView = true } = step;
+    try {
+      const result = await sendAction(tabId, {
+        type: 'click',
+        locator,
+        intent: intent || MESSAGE_CODES.CLICK.START,
+        scrollIntoView,
+      });
+      return buildOk(result.code || MESSAGE_CODES.CLICK.OK, result.details, { intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.CLICK.FAIL, err, err.details, { intent });
+    }
+  }
+
+  async function inputText(tabId, step = {}) {
+    const { locator = {}, text = '', typingSpeed, intent, replace = true } = step;
+    try {
+      const result = await sendAction(tabId, {
+        type: 'type',
+        locator,
+        text,
+        typingSpeed,
+        replace,
+        intent: intent || MESSAGE_CODES.INPUT.START,
+      });
+      return buildOk(result.code || MESSAGE_CODES.INPUT.OK, result.details, { intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.INPUT.FAIL, err, err.details, { intent });
+    }
+  }
+
+  async function selectDropdownOption(tabId, step = {}) {
+    const { locator = {}, text = '', intent } = step;
+    try {
+      const result = await sendAction(tabId, {
+        type: 'select',
+        locator,
+        text,
+        intent: intent || MESSAGE_CODES.SELECT.START,
+      });
+      return buildOk(result.code || MESSAGE_CODES.SELECT.OK, result.details, { intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.SELECT.FAIL, err, err.details, { intent });
+    }
+  }
+
+  async function scroll(tabId, step = {}) {
+    const { intent, mode = 'element', locator = {}, percent, behavior, offset = 0 } = step;
+    try {
+      const result = await sendAction(tabId, {
+        type: 'scroll',
+        intent: intent || MESSAGE_CODES.SCROLL.START,
+        locator,
+        mode,
+        percent,
+        behavior,
+        offset,
+      });
+      return buildOk(result.code || MESSAGE_CODES.SCROLL.OK, result.details, { intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.SCROLL.FAIL, err, err.details, { intent });
+    }
+  }
+
+  async function goToUrl(tabId, step = {}) {
+    const { url, intent } = step;
+    if (!url) return buildFail(MESSAGE_CODES.NAVIGATE.FAIL, new Error('NO_URL'), {}, { intent });
+    try {
+      await chrome.tabs.update(tabId, { url });
+      return buildOk(MESSAGE_CODES.NAVIGATE.OK, { url }, { intent });
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.NAVIGATE.FAIL, err, { url }, { intent });
+    }
+  }
+
+  async function goBack(tabId, step = {}) {
+    const { intent } = step;
+    try {
+      await chrome.tabs.goBack(tabId);
+      return buildOk(MESSAGE_CODES.BACK.OK, {}, { intent });
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.BACK.FAIL, err, {}, { intent });
+    }
+  }
+
+  async function goForward(tabId, step = {}) {
+    const { intent } = step;
+    try {
+      await chrome.tabs.goForward(tabId);
+      return buildOk(MESSAGE_CODES.FORWARD.OK, {}, { intent });
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.FORWARD.FAIL, err, {}, { intent });
+    }
+  }
+
+  async function reload(tabId, step = {}) {
+    const { intent, bypassCache = false } = step;
+    try {
+      await chrome.tabs.reload(tabId, { bypassCache });
+      return buildOk(MESSAGE_CODES.RELOAD.OK, { bypassCache }, { intent });
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.RELOAD.FAIL, err, { bypassCache }, { intent });
+    }
+  }
+
+  async function wait(step = {}) {
+    const { seconds = 1, intent } = step;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, Math.max(0, seconds) * 1000));
+      return buildOk(MESSAGE_CODES.WAIT.OK, { seconds }, { intent });
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.WAIT.FAIL, err, { seconds }, { intent });
+    }
+  }
+
+  async function statusUpdate(tabId, step = {}) {
+    const message = step.message || step.text;
+    if (!message) {
+      return buildFail(MESSAGE_CODES.STATUS.FAIL, new Error('NO_STATUS_MESSAGE'));
+    }
+    try {
+      await ensureContentScript(tabId);
+      await chrome.tabs.sendMessage(tabId, {
+        type: 'SURVEY_AGENT_STATUS_UPDATE',
+        message,
+        tone: step.tone,
+        persist: step.persist === true,
+      });
+      return buildOk(MESSAGE_CODES.STATUS.OK, { statusMessage: message, tone: step.tone }, {});
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.STATUS.FAIL, err, { message }, {});
+    }
+  }
+
+  async function ipInfo(tabId, step = {}) {
+    try {
+      const result = await sendAction(tabId, {
+        type: 'ip_info',
+        intent: step.intent || MESSAGE_CODES.IP_INFO.START,
+        mode: step.mode,
+      });
+      return buildOk(result.code || MESSAGE_CODES.IP_INFO.OK, result.details, { intent: step.intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.IP_INFO.FAIL, err, err.details, { intent: step.intent });
+    }
+  }
+
+  async function ipCheck(tabId, step = {}) {
+    try {
+      const result = await sendAction(tabId, {
+        type: 'ip_check',
+        intent: step.intent || MESSAGE_CODES.IP_CHECK.START,
+        mode: step.mode,
+      });
+      return buildOk(result.code || MESSAGE_CODES.IP_CHECK.OK, result.details, { intent: step.intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.IP_CHECK.FAIL, err, err.details, { intent: step.intent });
+    }
+  }
+
+  async function customOpen(tabId, step = {}) {
+    try {
+      const result = await sendAction(tabId, {
+        type: 'custom_open',
+        siteKey: step.siteKey,
+        url: step.url,
+        intent: step.intent || MESSAGE_CODES.CUSTOM_OPEN.START,
+      });
+      return buildOk(result.code || MESSAGE_CODES.CUSTOM_OPEN.OK, result.details, { intent: step.intent });
+    } catch (err) {
+      return buildFail(err.code || MESSAGE_CODES.CUSTOM_OPEN.FAIL, err, err.details, { intent: step.intent });
+    }
+  }
+
+  async function saveNote(step = {}) {
+    const content = step.content || step.text;
+    if (!content) {
+      return buildFail(MESSAGE_CODES.NOTE_SAVE.FAIL, new Error('NO_NOTE_CONTENT'));
+    }
+    const title = step.title || 'ملاحظة الوكيل';
+    try {
+      const entry = {
+        id: `agent-note-${Date.now()}`,
+        title: String(title).slice(0, 160),
+        content: String(content),
+        createdAt: Date.now(),
+        source: 'survey-agent',
+      };
+      const { surveyAgentNotes = [] } = await chrome.storage.local.get('surveyAgentNotes');
+      surveyAgentNotes.push(entry);
+      await chrome.storage.local.set({ surveyAgentNotes });
+      return buildOk(MESSAGE_CODES.NOTE_SAVE.OK, { title: entry.title, createdAt: entry.createdAt }, {});
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.NOTE_SAVE.FAIL, err, {}, {});
+    }
+  }
+
+  async function openTab(step = {}) {
+    const url = step.url;
+    if (!url) {
+      return buildFail(MESSAGE_CODES.OPEN_TAB.FAIL, new Error('NO_URL'), {}, {});
+    }
+    try {
+      const tab = await chrome.tabs.create({ url, active: step.active !== false });
+      return buildOk(MESSAGE_CODES.OPEN_TAB.OK, { url, tabId: tab?.id }, {});
+    } catch (err) {
+      return buildFail(MESSAGE_CODES.OPEN_TAB.FAIL, err, { url }, {});
+    }
+  }
+
+  async function execute(tabId, step = {}) {
+    if (!step || typeof step !== 'object') {
+      return buildFail('act_errors_invalidAction', new Error('INVALID_ACTION'));
+    }
+    const type = typeof step.type === 'string' ? step.type : step.name;
+    const normalized = typeof type === 'string' ? type.toLowerCase() : '';
+    switch (normalized) {
+      case 'click':
+        return click(tabId, step);
+      case 'type':
+      case 'input_text':
+        return inputText(tabId, step);
+      case 'select':
+      case 'select_dropdown_option':
+        return selectDropdownOption(tabId, step);
+      case 'scroll':
+      case 'scroll_to':
+        return scroll(tabId, step);
+      case 'go_to_url':
+      case 'navigate':
+        return goToUrl(tabId, step);
+      case 'go_back':
+        return goBack(tabId, step);
+      case 'go_forward':
+        return goForward(tabId, step);
+      case 'reload':
+        return reload(tabId, step);
+      case 'wait':
+        return wait(step);
+      case 'status':
+        return statusUpdate(tabId, step);
+      case 'ip_info':
+        return ipInfo(tabId, step);
+      case 'ip_check':
+        return ipCheck(tabId, step);
+      case 'custom_open':
+        return customOpen(tabId, step);
+      case 'note_save':
+        return saveNote(step);
+      case 'open_tab':
+        return openTab(step);
+      default:
+        return buildFail('act_errors_unknownAction', new Error(`Unknown action: ${type || 'undefined'}`));
+    }
+  }
+
+  globalThis.surveyAgentActions = {
+    click,
+    inputText,
+    selectDropdownOption,
+    scroll,
+    goToUrl,
+    goBack,
+    goForward,
+    reload,
+    wait,
+    statusUpdate,
+    ipInfo,
+    ipCheck,
+    customOpen,
+    saveNote,
+    openTab,
+    execute,
+  };
+})(self);

--- a/zepra/RESUELV2/src/agent/planner.js
+++ b/zepra/RESUELV2/src/agent/planner.js
@@ -1,0 +1,885 @@
+/*
+ * Survey Agent planner
+ * Builds chunked action plans from DOM summaries using Cerebras chat completions.
+ */
+(function attachSurveyAgentPlanner(globalThis) {
+  const ALLOWED_ACTION_TYPES = new Set([
+    'click',
+    'type',
+    'select',
+    'scroll',
+    'navigate',
+    'back',
+    'forward',
+    'reload',
+    'wait',
+    'status',
+    'ip_info',
+    'ip_check',
+    'custom_open',
+    'note_save',
+    'open_tab',
+  ]);
+
+  const MAX_HISTORY_ITEMS = 12;
+  const MAX_CHAT_ITEMS = 12;
+  const MAX_NODE_SUMMARY = 140;
+  const MAX_ATTR_LENGTH = 80;
+  const MAX_NODES = 120;
+
+  const DEFAULT_RULES_TEXT = [
+    '- Respond with JSON ONLY. No code fences, markdown, or commentary.',
+    '- Reference elements by their highlight index when available.',
+    '- Use status "done" only when the survey appears complete.',
+    '- Use status "abort" if the task cannot progress.',
+    '- For "type" actions include the "text" field.',
+    '- For dropdowns or multiple choice, use "select" with the desired option text.',
+    '- When filling known profile information, set step.intent to "identity.<field>" and use text "{{IDENTITY.<field>}}".',
+    '- Prefer profile data over inventing new answers when identity placeholders are available.',
+    '- Consider OCR hints when planning steps for image-based questions.',
+    '- You may navigate to other URLs or tabs when the instructions require visiting different pages.',
+    '- Use "status" actions to update the status bar (msg/tone) instead of adding chat entries.',
+    '- Use "ip_info" to open the IP information panel and "ip_check" to run qualification when needed.',
+    '- Use "custom_open" to launch custom web helpers (siteKey or url) and summarise results.',
+    '- Use "note_save" with {title, content} to archive important outputs in notes.',
+    '- Use "open_tab" to spawn helper tabs without blocking the current page.',
+    '- Propose exactly ONE next action (chunked planning).',
+    '- Keep operator-facing explanations and follow-up questions in Arabic, concise and friendly.',
+    '- Ask for clarification only when necessary, using a single direct Arabic question.',
+    '- Never copy the operator\'s raw chat message into any form field or action text.'
+  ].join('\n');
+
+  const DEFAULT_FORMAT_GUIDE = '{\n'
+    + '  "status": "continue" | "done" | "abort",\n'
+    + '  "explanation": "Short natural language reasoning",\n'
+    + '  "step": {\n'
+    + '    "type": "click" | "type" | "select" | "scroll" | "navigate" | "back" | "forward" | "reload" | "wait" | "status" | "ip_info" | "ip_check" | "custom_open" | "note_save" | "open_tab",\n'
+    + '    "locator": { "highlightIndex": number?, "xpath": string?, "cssSelector": string? },\n'
+    + '    "text": string?,\n'
+    + '    "url": string?,\n'
+    + '    "ms": number?,\n'
+    + '    "intent": string?,\n'
+    + '    "message": string?,\n'
+    + '    "tone": string?,\n'
+    + '    "siteKey": string?,\n'
+    + '    "title": string?,\n'
+    + '    "content": string?,\n'
+    + '    "active": boolean?\n'
+    + '  },\n'
+    + '  "confidence": number (0-1)\n'
+    + '}';
+
+  const DEFAULT_PROMPT_TEMPLATE = [
+    "You are Zepra's survey automation planner. You see a DOM snapshot of a survey page and a short history of executed actions.",
+    'Plan ONLY the next action needed to progress towards completing the survey.',
+    '',
+    '{{GOAL_SECTION}}',
+    '',
+    'Allowed action types:',
+    '{{ALLOWED_ACTIONS}}',
+    '',
+    'Response format:',
+    '{{FORMAT_GUIDE}}',
+    '',
+    'Rules:',
+    '{{RULES}}',
+    '',
+    'DOM summary:',
+    '{{DOM_SUMMARY}}',
+    '',
+    'Recent history:',
+    '{{HISTORY}}',
+    '',
+    'Operator chat history:',
+    '{{CHAT_HISTORY}}',
+    '',
+    'Identity profile:',
+    '{{IDENTITY}}',
+    '',
+    'Image/OCR hints:',
+    '{{MEDIA_HINTS}}',
+    '',
+    'Page context:',
+    '{{PAGE_CONTEXT}}',
+    '',
+    'Respond with the JSON schema shown above.{{EXTRA_INSTRUCTIONS}}',
+    '',
+    'Wrap your final reply like this:',
+    '{',
+    '  "thought": "...",',
+    '  "needsOCR": [ { "reason": "...", "rect": [x,y,w,h] | null } ],',
+    '  "actions": [ { "cmd":"dom.scan","id":"S1" }, { "cmd":"click","args":{"css":"button.next"},"id":"S2" } ],',
+    '  "finishWhen": "Plain-EN condition e.g. DOM contains text \'Thank you\'",',
+    '  "user_followup": false',
+    '}',
+    'ZEPRA_PLAN```'
+  ].join('\n');
+
+  globalThis.SURVEY_AGENT_DEFAULT_PROMPT_TEMPLATE = DEFAULT_PROMPT_TEMPLATE;
+
+  function safeJsonParse(text) {
+    if (!text) return null;
+    const rawText = typeof text === 'string' ? text : JSON.stringify(text);
+    const cleaned = stripPlanWrappers(rawText);
+    try {
+      return JSON.parse(cleaned);
+    } catch (err) {
+      const start = cleaned.indexOf('{');
+      const end = cleaned.lastIndexOf('}');
+      if (start !== -1 && end !== -1 && end > start) {
+        const candidate = cleaned.slice(start, end + 1);
+        try {
+          return JSON.parse(candidate);
+        } catch (nestedErr) {
+          return null;
+        }
+      }
+      return null;
+    }
+  }
+
+  function stripPlanWrappers(text) {
+    if (!text) return '';
+    let output = String(text);
+    if (output.includes('ZEPRA_PLAN')) {
+      output = output.split('ZEPRA_PLAN')[0];
+    }
+    output = output.replace(/```json/gi, '');
+    output = output.replace(/```/g, '');
+    return output.trim();
+  }
+
+  function truncate(str, max = MAX_NODE_SUMMARY) {
+    if (!str) return '';
+    const s = String(str).trim();
+    if (s.length <= max) return s;
+    return `${s.slice(0, max - 1)}…`;
+  }
+
+  function collectTextFromNode(nodeId, map, visited, limit) {
+    if (!nodeId || !map || visited.has(nodeId)) return '';
+    visited.add(nodeId);
+    const node = map[nodeId];
+    if (!node) return '';
+    if (typeof node.text === 'string') {
+      return truncate(node.text, limit);
+    }
+    let buffer = '';
+    if (Array.isArray(node.children)) {
+      for (const childId of node.children) {
+        if (buffer.length >= limit) break;
+        buffer += ` ${collectTextFromNode(childId, map, visited, limit - buffer.length)}`;
+      }
+    }
+    if (buffer) return truncate(buffer, limit);
+    if (node.attributes) {
+      const labelAttr = node.attributes['aria-label'] || node.attributes['aria-labelledby'];
+      if (labelAttr) return truncate(labelAttr, limit);
+      const placeholder = node.attributes.placeholder;
+      if (placeholder) return truncate(placeholder, limit);
+      const value = node.attributes.value;
+      if (value) return truncate(value, limit);
+      const name = node.attributes.name;
+      if (name) return truncate(name, limit);
+    }
+    return '';
+  }
+
+  function buildNodeSummaryEntries(tree, options = {}) {
+    const map = tree && tree.map ? tree.map : null;
+    if (!map) return [];
+    const summaries = [];
+    const maxNodes = Number.isInteger(options.maxNodes) ? options.maxNodes : MAX_NODES;
+    for (const [id, node] of Object.entries(map)) {
+      if (!node || typeof node !== 'object') continue;
+      const highlightIndex = Number.isInteger(node.highlightIndex) ? node.highlightIndex : null;
+      const hasOcr = typeof node.ocrText === 'string' && node.ocrText.trim().length;
+      const isInteractive = Boolean(node.isInteractive || node.isTopElement || highlightIndex !== null);
+      if (!isInteractive && !hasOcr) continue;
+      const text = collectTextFromNode(id, map, new Set(), MAX_NODE_SUMMARY);
+      const attributes = node.attributes || {};
+      const attrPairs = [];
+      for (const [key, value] of Object.entries(attributes)) {
+        if (value === undefined || value === null || value === '') continue;
+        const printable = truncate(value, MAX_ATTR_LENGTH);
+        attrPairs.push(`${key}="${printable}"`);
+      }
+      const attrSummary = attrPairs.length ? attrPairs.join(' ') : '';
+      const summary = {
+        id,
+        highlightIndex,
+        tag: node.tagName || node.type || 'node',
+        xpath: node.xpath ? truncate(node.xpath, 200) : undefined,
+        attr: attrSummary,
+        text,
+        isInteractive: Boolean(node.isInteractive),
+        isVisible: node.isVisible !== false,
+        inViewport: node.isInViewport !== false,
+      };
+      if (node.isRequired) summary.required = true;
+      const currentValue = typeof node.currentValue === 'string' ? node.currentValue.trim() : '';
+      const selectedTexts = Array.isArray(node.selectedTexts) ? node.selectedTexts.filter(Boolean) : [];
+      const selectedValues = Array.isArray(node.selectedValues) ? node.selectedValues.filter(Boolean) : [];
+      const hasSelection = selectedTexts.length || selectedValues.length;
+      if (currentValue) summary.value = truncate(currentValue, MAX_ATTR_LENGTH);
+      if (hasSelection) {
+        const combined = selectedTexts.length ? selectedTexts.join(', ') : selectedValues.join(', ');
+        summary.selected = truncate(combined, MAX_ATTR_LENGTH * 2);
+      }
+      if (typeof node.isChecked === 'boolean') summary.checked = node.isChecked;
+      if (node.isMultiple) summary.multiple = true;
+      const isFormField =
+        (node.tagName && ['input', 'textarea', 'select'].includes(String(node.tagName).toLowerCase())) ||
+        currentValue !== '' ||
+        hasSelection ||
+        typeof node.isChecked === 'boolean';
+      if (isFormField) {
+        const hasValue =
+          Boolean(summary.value && summary.value.trim()) ||
+          Boolean(summary.selected && summary.selected.trim()) ||
+          summary.checked === true;
+        summary.filled = hasValue;
+      }
+      if (node.identityKey) summary.identityKey = node.identityKey;
+      if (node.identityPreview) summary.identityPreview = truncate(node.identityPreview, MAX_NODE_SUMMARY);
+      if (hasOcr) summary.ocrText = truncate(node.ocrText, 200);
+      summaries.push(summary);
+    }
+    summaries.sort((a, b) => {
+      const ai = a.highlightIndex === null || a.highlightIndex === undefined ? Number.POSITIVE_INFINITY : a.highlightIndex;
+      const bi = b.highlightIndex === null || b.highlightIndex === undefined ? Number.POSITIVE_INFINITY : b.highlightIndex;
+      if (ai !== bi) return ai - bi;
+      return a.id.localeCompare(b.id);
+    });
+    return summaries.slice(0, maxNodes);
+  }
+
+  function formatSummaryForPrompt(entries) {
+    if (!entries.length) return 'No interactive nodes detected.';
+    return entries
+      .map((entry) => {
+        const parts = [];
+        if (entry.highlightIndex !== null && entry.highlightIndex !== undefined) {
+          parts.push(`#${entry.highlightIndex}`);
+        }
+        parts.push(`<${entry.tag}>`);
+        if (entry.attr) parts.push(entry.attr);
+        if (entry.required) parts.push('required');
+        if (entry.text) parts.push(`text="${entry.text}"`);
+        if (entry.value) parts.push(`value="${entry.value}"`);
+        if (entry.selected) parts.push(`selected="${truncate(entry.selected, 160)}"`);
+        if (entry.checked === true) parts.push('checked');
+        if (entry.checked === false && entry.tag && entry.tag.toLowerCase() === 'input') parts.push('unchecked');
+        if (entry.filled === false) parts.push('empty');
+        parts.push(entry.isVisible ? 'visible' : 'hidden');
+        if (!entry.inViewport) parts.push('offViewport');
+        if (entry.identityKey) {
+          const preview = entry.identityPreview ? ` (${truncate(entry.identityPreview, 60)})` : '';
+          parts.push(`identity=${entry.identityKey}${preview}`);
+        }
+        if (entry.ocrText) parts.push(`ocr="${truncate(entry.ocrText, 120)}"`);
+        if (entry.xpath) parts.push(`xpath=${entry.xpath}`);
+        return parts.join(' | ');
+      })
+      .join('\n');
+  }
+
+  function formatHistoryForPrompt(history) {
+    if (!Array.isArray(history) || history.length === 0) return 'None.';
+    const recent = history.slice(-MAX_HISTORY_ITEMS);
+    return recent
+      .map((item, idx) => {
+        const step = item?.step || item?.action || {};
+        const result = item?.result || item || {};
+        const type = (step.type || '').toLowerCase();
+        const hi = step.locator && Number.isInteger(step.locator.highlightIndex)
+          ? `#${step.locator.highlightIndex}`
+          : '';
+        const value = step.text || step.url || step.option || step.ms || '';
+        const status = result.status || (result.ok === false ? 'fail' : 'ok');
+        const code = result.code ? ` (${result.code})` : '';
+        const err = result.error ? ` error="${truncate(result.error, 80)}"` : '';
+        return `${idx + 1}. ${type || 'unknown'} ${hi} ${value ? `value="${truncate(value, 60)}" ` : ''}-> ${status}${code}${err}`;
+      })
+      .join('\n');
+  }
+
+  function formatConversationForPrompt(conversation) {
+    if (!Array.isArray(conversation) || conversation.length === 0) return 'None.';
+    const recent = conversation.slice(-MAX_CHAT_ITEMS);
+    const lines = [];
+    for (const entry of recent) {
+      if (!entry || typeof entry.text !== 'string') continue;
+      const role = entry.role === 'agent' ? 'Agent' : entry.role === 'system' ? 'System' : 'Operator';
+      lines.push(`${role}: ${truncate(entry.text, 180)}`);
+    }
+    return lines.length ? lines.join('\n') : 'None.';
+  }
+
+  function formatIdentityContext(identity = {}, preview = {}) {
+    const entries = Object.entries(identity || {}).filter(([, value]) => typeof value === 'string' && value.trim());
+    if (!entries.length) return 'None.';
+    return entries
+      .slice(0, 24)
+      .map(([key, value]) => {
+        const shown = preview && typeof preview[key] === 'string' && preview[key].trim()
+          ? preview[key]
+          : value;
+        return `- ${key}: ${truncate(shown, 160)}`;
+      })
+      .join('\n');
+  }
+
+  function formatMediaHints(entries) {
+    const hints = [];
+    for (const entry of entries || []) {
+      if (!entry || !entry.ocrText) continue;
+      const label = entry.highlightIndex !== null && entry.highlightIndex !== undefined
+        ? `#${entry.highlightIndex}`
+        : `<${entry.tag}>`;
+      hints.push(`${label}: ${truncate(entry.ocrText, 160)}`);
+    }
+    return hints.length ? hints.join('\n') : 'None.';
+  }
+
+  function formatPageContext(page = {}) {
+    const lines = [];
+    if (page.url) lines.push(`- URL: ${page.url}`);
+    if (page.title) lines.push(`- Title: ${page.title}`);
+    if (page.language) lines.push(`- Language: ${page.language}`);
+    if (page.formProgress) lines.push(`- Form progress: ${page.formProgress}`);
+    return lines.length ? lines.join('\n') : 'None.';
+  }
+
+  function applyTemplate(template, mapping) {
+    let output = String(template ?? '');
+    for (const [key, value] of Object.entries(mapping || {})) {
+      const pattern = new RegExp(`{{\\s*${key}\\s*}}`, 'g');
+      output = output.replace(pattern, () => String(value ?? ''));
+    }
+    return output;
+  }
+
+  function buildPlannerPrompt({
+    domSummaryText,
+    historyText,
+    goal,
+    instructions,
+    template,
+    identityText,
+    mediaText,
+    pageText,
+    chatText,
+    preferences,
+  }) {
+    const allowedActions = Array.from(ALLOWED_ACTION_TYPES)
+      .map((type) => `- ${type}`)
+      .join('\n');
+    const goalSection = goal ? `Goal: ${goal}` : 'Goal: Complete the requested task carefully.';
+    const extraParts = [];
+    if (instructions) {
+      extraParts.push(`Additional operator note: ${instructions}`);
+    }
+    if (preferences) {
+      if (preferences.useIdentityAnswers === true) {
+        extraParts.push('Identity autofill is enabled: prefer the provided profile data for matching fields and avoid inventing conflicting answers.');
+      } else if (preferences.useIdentityAnswers === false) {
+        extraParts.push('Identity autofill is disabled: craft suitable values yourself instead of relying on identity placeholders.');
+      }
+      if (preferences.deliberateMode) {
+        extraParts.push('Work methodically: avoid repeating the same action without change, ensure every required field is filled exactly once, and insert wait or scroll actions when the page needs time to update.');
+      }
+    }
+    const extra = extraParts.length ? `\n${extraParts.join('\n')}` : '';
+    const source = template && String(template).trim().length ? template : DEFAULT_PROMPT_TEMPLATE;
+
+    let promptText = applyTemplate(source, {
+      GOAL_SECTION: goalSection,
+      ALLOWED_ACTIONS: allowedActions,
+      FORMAT_GUIDE: DEFAULT_FORMAT_GUIDE,
+      RULES: DEFAULT_RULES_TEXT,
+      DOM_SUMMARY: domSummaryText,
+      HISTORY: historyText,
+      CHAT_HISTORY: chatText && chatText.trim() ? chatText : 'None.',
+      IDENTITY: identityText && identityText.trim() ? identityText : 'None.',
+      MEDIA_HINTS: mediaText && mediaText.trim() ? mediaText : 'None.',
+      PAGE_CONTEXT: pageText && pageText.trim() ? pageText : 'None.',
+      EXTRA_INSTRUCTIONS: extra,
+    });
+
+    if (!source.includes('{{CHAT_HISTORY}}') && chatText && chatText.trim() && chatText.trim() !== 'None.') {
+      promptText = `${promptText}\n\nOperator chat history:\n${chatText}`;
+    }
+    if (!source.includes('{{IDENTITY}}') && identityText && identityText.trim()) {
+      promptText = `${promptText}\n\nIdentity profile:\n${identityText}`;
+    }
+    if (!source.includes('{{MEDIA_HINTS}}') && mediaText && mediaText.trim() && mediaText.trim() !== 'None.') {
+      promptText = `${promptText}\n\nImage/OCR hints:\n${mediaText}`;
+    }
+    if (!source.includes('{{PAGE_CONTEXT}}') && pageText && pageText.trim()) {
+      promptText = `${promptText}\n\nPage context:\n${pageText}`;
+    }
+
+    if (typeof globalThis.STRICT_JSON === 'string' && globalThis.STRICT_JSON.trim()) {
+      promptText = `${promptText}\n\n${globalThis.STRICT_JSON}`;
+    }
+
+    return promptText;
+  }
+
+  function normalizeLocator(locator = {}) {
+    if (!locator || typeof locator !== 'object') return {};
+    const out = {};
+    if (Number.isInteger(locator.highlightIndex)) out.highlightIndex = locator.highlightIndex;
+    if (locator.nodeId) out.nodeId = String(locator.nodeId);
+    if (locator.xpath) out.xpath = String(locator.xpath).slice(0, 400);
+    if (locator.cssSelector) out.cssSelector = String(locator.cssSelector).slice(0, 400);
+    if (Array.isArray(locator.frameChain)) {
+      out.frameChain = locator.frameChain
+        .map((frame) => ({
+          xpath: frame && frame.xpath ? String(frame.xpath).slice(0, 400) : undefined,
+          index: Number.isInteger(frame?.index) ? frame.index : undefined,
+        }))
+        .filter((frame) => frame.xpath || Number.isInteger(frame.index));
+    }
+    return out;
+  }
+
+  function normalizeStep(rawStep = {}) {
+    if (!rawStep || typeof rawStep !== 'object') return null;
+    const type = typeof rawStep.type === 'string' ? rawStep.type.toLowerCase() : '';
+    if (!ALLOWED_ACTION_TYPES.has(type)) return null;
+    const normalized = { type };
+    if (rawStep.intent) normalized.intent = String(rawStep.intent).slice(0, 160);
+    const locator = normalizeLocator(rawStep.locator);
+    if (Object.keys(locator).length) normalized.locator = locator;
+    if (type === 'type' || rawStep.text) {
+    if (rawStep.text === undefined) return null;
+      normalized.text = String(rawStep.text);
+      if (rawStep.typingSpeed) normalized.typingSpeed = String(rawStep.typingSpeed);
+      if (rawStep.replace !== undefined) normalized.replace = rawStep.replace !== false;
+    }
+    if (type === 'select' && rawStep.text !== undefined) {
+      normalized.text = String(rawStep.text);
+    }
+    if (type === 'scroll') {
+      if (rawStep.mode) normalized.mode = String(rawStep.mode);
+      if (rawStep.percent !== undefined) normalized.percent = Number(rawStep.percent);
+      if (rawStep.behavior) normalized.behavior = String(rawStep.behavior);
+      if (rawStep.offset !== undefined) normalized.offset = Number(rawStep.offset);
+    }
+    if (type === 'navigate' && rawStep.url) {
+      normalized.url = String(rawStep.url);
+    }
+    if (type === 'wait') {
+      const ms = Number(rawStep.ms ?? rawStep.duration ?? 0);
+      if (!Number.isFinite(ms) || ms < 0) return null;
+      normalized.ms = ms;
+    }
+    if (type === 'status') {
+      const message = rawStep.message ?? rawStep.text;
+      if (!message) return null;
+      normalized.message = String(message);
+      if (rawStep.tone) normalized.tone = String(rawStep.tone);
+      if (rawStep.persist !== undefined) normalized.persist = rawStep.persist === true;
+    }
+    if (type === 'ip_info' || type === 'ip_check') {
+      if (rawStep.mode) normalized.mode = String(rawStep.mode);
+    }
+    if (type === 'custom_open') {
+      if (rawStep.siteKey) normalized.siteKey = String(rawStep.siteKey);
+      if (rawStep.url) normalized.url = String(rawStep.url);
+      if (!normalized.siteKey && !normalized.url) return null;
+    }
+    if (type === 'note_save') {
+      const content = rawStep.content ?? rawStep.text ?? rawStep.value;
+      if (!content) return null;
+      normalized.content = String(content);
+      if (rawStep.title || rawStep.name || rawStep.label) {
+        normalized.title = String(rawStep.title || rawStep.name || rawStep.label);
+      }
+    }
+    if (type === 'open_tab') {
+      if (!rawStep.url) return null;
+      normalized.url = String(rawStep.url);
+      if (rawStep.active !== undefined) normalized.active = rawStep.active !== false;
+    }
+    return normalized;
+  }
+
+  function buildLocatorFromCommandArgs(args = {}) {
+    const locator = {};
+    if (Number.isInteger(args.highlightIndex)) locator.highlightIndex = args.highlightIndex;
+    const css = args.css || args.selector || args.sel;
+    if (typeof css === 'string' && css.trim()) locator.cssSelector = css.trim();
+    const xpath = args.xpath || args.path;
+    if (typeof xpath === 'string' && xpath.trim()) locator.xpath = xpath.trim();
+    const nodeId = args.nodeId || args.id;
+    if (typeof nodeId === 'string' && nodeId.trim()) locator.nodeId = nodeId.trim();
+    if (Array.isArray(args.frameChain)) {
+      locator.frameChain = args.frameChain
+        .map((frame) => ({
+          xpath: frame && frame.xpath ? String(frame.xpath).slice(0, 400) : undefined,
+          index: Number.isInteger(frame?.index) ? frame.index : undefined,
+        }))
+        .filter((frame) => frame.xpath || Number.isInteger(frame.index));
+    }
+    return locator;
+  }
+
+  function mapCommandToStep(action = {}) {
+    if (!action || typeof action !== 'object') return null;
+    const cmd = typeof action.cmd === 'string' ? action.cmd.toLowerCase() : '';
+    if (!cmd) return null;
+    const args = action.args || {};
+    switch (cmd) {
+      case 'click': {
+        const locator = buildLocatorFromCommandArgs(args);
+        return normalizeStep({ type: 'click', locator, intent: action.intent });
+      }
+      case 'type': {
+        const locator = buildLocatorFromCommandArgs(args);
+        const text = args.text ?? args.value;
+        if (text === undefined) return null;
+        return normalizeStep({
+          type: 'type',
+          locator,
+          text,
+          intent: action.intent,
+          typingSpeed: args.mode,
+          replace: args.replace,
+        });
+      }
+      case 'set': {
+        const locator = buildLocatorFromCommandArgs(args);
+        const text = args.text ?? args.value;
+        if (text === undefined) return null;
+        return normalizeStep({
+          type: 'type',
+          locator,
+          text,
+          intent: action.intent,
+          replace: true,
+        });
+      }
+      case 'select': {
+        const locator = buildLocatorFromCommandArgs(args);
+        const text = args.text ?? args.value;
+        if (text === undefined) return null;
+        return normalizeStep({ type: 'select', locator, text, intent: action.intent });
+      }
+      case 'scroll': {
+        const locator = buildLocatorFromCommandArgs(args);
+        const offset = Number.isFinite(args.y) ? Number(args.y) : Number(args.offset);
+        const percent = Number.isFinite(args.percent) ? Number(args.percent) : undefined;
+        const mode = args.mode || (Object.keys(locator).length ? 'element' : args.target === 'page' ? 'page' : undefined);
+        return normalizeStep({
+          type: 'scroll',
+          locator: Object.keys(locator).length ? locator : undefined,
+          offset,
+          percent,
+          behavior: args.behavior,
+          mode,
+          intent: action.intent,
+        });
+      }
+      case 'status': {
+        const message = args.msg ?? args.message ?? args.text;
+        if (!message) return null;
+        return normalizeStep({
+          type: 'status',
+          message,
+          tone: args.tone || args.level,
+          persist: args.persist,
+          intent: action.intent,
+        });
+      }
+      case 'ip.check':
+      case 'ip_check': {
+        return normalizeStep({
+          type: 'ip_check',
+          mode: args.mode || args.target,
+          intent: action.intent,
+        });
+      }
+      case 'ip.info':
+      case 'ip_info': {
+        return normalizeStep({
+          type: 'ip_info',
+          mode: args.mode || args.section,
+          intent: action.intent,
+        });
+      }
+      case 'custom.open':
+      case 'custom_open': {
+        return normalizeStep({
+          type: 'custom_open',
+          siteKey: args.siteKey || args.key || args.slot,
+          url: args.url,
+          intent: action.intent,
+        });
+      }
+      case 'note.save':
+      case 'note_save': {
+        return normalizeStep({
+          type: 'note_save',
+          title: args.title || args.name || args.label,
+          content: args.content ?? args.text ?? args.value,
+          intent: action.intent,
+        });
+      }
+      case 'open.tab':
+      case 'open_tab': {
+        return normalizeStep({
+          type: 'open_tab',
+          url: args.url,
+          active: args.active !== false,
+          intent: action.intent,
+        });
+      }
+      case 'wait': {
+        const ms = Number.isFinite(args.ms) ? Number(args.ms) : Number(args.duration);
+        return normalizeStep({ type: 'wait', ms: Number.isFinite(ms) ? ms : 0, intent: action.intent });
+      }
+      default:
+        return null;
+    }
+  }
+
+  function translateZepraPlanEnvelope(envelope = {}) {
+    if (!envelope || typeof envelope !== 'object') return null;
+    const result = {
+      status: 'continue',
+      explanationParts: [],
+      needsOCR: Array.isArray(envelope.needsOCR) ? envelope.needsOCR : [],
+      finishWhen: envelope.finishWhen,
+      userFollowup: envelope.user_followup === true,
+      actionsPlanned: Array.isArray(envelope.actions) ? envelope.actions.length : 0,
+      rawEnvelope: envelope,
+      steps: [],
+    };
+    if (envelope.thought) {
+      const thought = String(envelope.thought).trim();
+      if (thought) result.explanationParts.push(thought);
+    }
+
+    const actions = Array.isArray(envelope.actions) ? envelope.actions : [];
+    for (const action of actions) {
+      const cmd = typeof action?.cmd === 'string' ? action.cmd.toLowerCase() : '';
+      if (!cmd) continue;
+      if (cmd === 'dom.scan') {
+        result.steps.push({
+          kind: 'dom_scan',
+          id: action?.id || null,
+          args: action?.args || {},
+        });
+        continue;
+      }
+      if (cmd === 'done') {
+        result.status = 'done';
+        const message = action?.args?.summary || action?.args?.message || '';
+        if (message) result.explanationParts.push(String(message));
+        result.steps.push({
+          kind: 'done',
+          id: action?.id || null,
+          args: action?.args || {},
+        });
+        result.step = null;
+        break;
+      }
+      if (cmd === 'status') {
+        const message = action?.args?.msg || action?.args?.message || action?.args?.text;
+        if (message) {
+          const tone = action?.args?.tone || action?.args?.level;
+          const persist = action?.args?.persist === true;
+          if (!Array.isArray(result.statusUpdates)) result.statusUpdates = [];
+          result.statusUpdates.push({
+            message: String(message),
+            tone: tone ? String(tone) : undefined,
+            persist,
+          });
+          result.explanationParts.push(String(message));
+        }
+        continue;
+      }
+      if (cmd === 'ocr.capture') {
+        const rect = Array.isArray(action?.args?.rect) ? action.args.rect : null;
+        if (!result.needsOCR.length) {
+          result.needsOCR = [{ reason: action?.args?.reason || 'planner-request', rect }];
+        }
+        result.steps.push({
+          kind: 'ocr_capture',
+          id: action?.id || null,
+          args: action?.args || {},
+          rect,
+          reason: action?.args?.reason || action?.args?.label || null,
+        });
+        continue;
+      }
+      const step = mapCommandToStep(action);
+      if (step) {
+        if (!result.step) {
+          result.step = step;
+        }
+        result.steps.push({
+          kind: 'action',
+          id: action?.id || null,
+          step,
+          raw: action,
+        });
+        continue;
+      }
+    }
+
+    if (!result.step && result.status === 'continue' && result.userFollowup) {
+      result.status = 'abort';
+      if (!result.explanationParts.length) {
+        result.explanationParts.push('بحاجة إلى توضيح إضافي.');
+      }
+    }
+
+    result.explanation = result.explanationParts.join(' ').trim();
+    return result;
+  }
+
+  async function planNext(params = {}) {
+    const { domTree, history = [], goal, instructions, options = {}, context = {}, conversation = [] } = params;
+    if (!domTree) {
+      const err = new Error('MISSING_DOM_TREE');
+      err.code = 'MISSING_DOM_TREE';
+      throw err;
+    }
+    if (typeof globalThis.callCerebras !== 'function') {
+      const err = new Error('LLM_UNAVAILABLE');
+      err.code = 'LLM_UNAVAILABLE';
+      throw err;
+    }
+
+    const summaries = buildNodeSummaryEntries(domTree, options);
+    const domSummaryText = formatSummaryForPrompt(summaries);
+    const historyText = formatHistoryForPrompt(history);
+    const chatText = formatConversationForPrompt(conversation);
+
+    let customTemplate = null;
+    try {
+      const stored = await chrome.storage.local.get('surveyPlannerPromptTemplate');
+      const tpl = stored?.surveyPlannerPromptTemplate;
+      if (typeof tpl === 'string' && tpl.trim().length) {
+        customTemplate = tpl;
+      }
+    } catch (err) {
+      console.warn('Survey planner: failed to load custom prompt template', err);
+    }
+
+    const identityText = formatIdentityContext(context.identity || {}, context.identityPreview || {});
+    const mediaText = formatMediaHints(summaries);
+    const pageText = formatPageContext(context.page || {});
+
+    const prompt = buildPlannerPrompt({
+      domSummaryText,
+      historyText,
+      goal,
+      instructions,
+      template: customTemplate,
+      identityText,
+      mediaText,
+      pageText,
+      chatText,
+      preferences: options.preferences || {},
+    });
+
+    let raw;
+    try {
+      raw = await globalThis.callCerebras(prompt);
+    } catch (err) {
+      err.code = err.code || 'LLM_CALL_FAILED';
+      throw err;
+    }
+
+    const parsed = safeJsonParse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      const err = new Error('INVALID_JSON_RESPONSE');
+      err.code = 'INVALID_JSON_RESPONSE';
+      err.details = { raw };
+      throw err;
+    }
+
+    let payload = parsed;
+    let translated = null;
+    if (Array.isArray(parsed.actions) || parsed.user_followup !== undefined || parsed.thought !== undefined) {
+      translated = translateZepraPlanEnvelope(parsed);
+      if (!translated) {
+        const err = new Error('INVALID_PLAN_ENVELOPE');
+        err.code = 'INVALID_PLAN_ENVELOPE';
+        err.details = { raw, parsed };
+        throw err;
+      }
+      payload = {
+        status: translated.status,
+        explanation: translated.explanation,
+        confidence: Number.isFinite(parsed.confidence) ? Number(parsed.confidence) : null,
+        step: translated.step || null,
+      };
+    }
+
+    const status = typeof payload.status === 'string' ? payload.status.toLowerCase() : 'continue';
+    const explanation = payload.explanation ? String(payload.explanation) : '';
+    const confidence = Number.isFinite(payload.confidence) ? Number(payload.confidence) : null;
+    const normalizedStep = translated ? (translated.step || null) : normalizeStep(payload.step || payload.action || {});
+
+    if (status === 'continue' && !normalizedStep) {
+      const err = new Error('PLANNER_STEP_REQUIRED');
+      err.code = 'PLANNER_STEP_REQUIRED';
+      err.details = { raw, parsed };
+      throw err;
+    }
+
+    const stepList = Array.isArray(translated?.steps)
+      ? translated.steps
+      : normalizedStep
+      ? [
+          {
+            kind: 'action',
+            id: null,
+            step: normalizedStep,
+          },
+        ]
+      : [];
+
+    const meta = {
+      nodesConsidered: summaries.length,
+      historyCount: Array.isArray(history) ? history.length : 0,
+    };
+    if (translated) {
+      if (Array.isArray(translated.needsOCR) && translated.needsOCR.length) {
+        meta.needsOCR = translated.needsOCR;
+      }
+      if (translated.finishWhen) meta.finishWhen = translated.finishWhen;
+      if (translated.userFollowup === true) meta.userFollowup = true;
+      if (Number.isFinite(translated.actionsPlanned)) meta.actionsPlanned = translated.actionsPlanned;
+      if (Array.isArray(translated.statusUpdates) && translated.statusUpdates.length) {
+        meta.statusUpdates = translated.statusUpdates;
+      }
+      meta.planEnvelope = translated.rawEnvelope;
+      if (Array.isArray(translated.steps)) {
+        meta.planSteps = translated.steps;
+      }
+    }
+
+    return {
+      ok: true,
+      status,
+      step: normalizedStep || null,
+      steps: stepList,
+      explanation,
+      confidence,
+      raw,
+      meta,
+    };
+  }
+
+  globalThis.surveyAgentPlanner = {
+    summarizeDomTree: buildNodeSummaryEntries,
+    planNext,
+  };
+})(self);

--- a/zepra/RESUELV2/src/dom/buildDomTree.js
+++ b/zepra/RESUELV2/src/dom/buildDomTree.js
@@ -1,0 +1,1559 @@
+function buildDomTree(
+  args = {
+    showHighlightElements: true,
+    focusHighlightIndex: -1,
+    viewportExpansion: 0,
+    debugMode: false,
+    startId: 0,
+    startHighlightIndex: 0,
+  },
+) {
+  const { showHighlightElements, focusHighlightIndex, viewportExpansion, startHighlightIndex, startId, debugMode } =
+    args;
+  // Make sure to do highlight elements always, but we can hide the highlights if needed
+  const doHighlightElements = true;
+
+  let highlightIndex = startHighlightIndex; // Reset highlight index
+
+  // Add caching mechanisms at the top level
+  const DOM_CACHE = {
+    boundingRects: new WeakMap(),
+    clientRects: new WeakMap(),
+    computedStyles: new WeakMap(),
+    clearCache: () => {
+      DOM_CACHE.boundingRects = new WeakMap();
+      DOM_CACHE.clientRects = new WeakMap();
+      DOM_CACHE.computedStyles = new WeakMap();
+    },
+  };
+
+  /**
+   * Gets the cached bounding rect for an element.
+   *
+   * @param {HTMLElement} element - The element to get the bounding rect for.
+   * @returns {DOMRect | null} The cached bounding rect, or null if the element is not found.
+   */
+  function getCachedBoundingRect(element) {
+    if (!element) return null;
+
+    if (DOM_CACHE.boundingRects.has(element)) {
+      return DOM_CACHE.boundingRects.get(element);
+    }
+
+    const rect = element.getBoundingClientRect();
+
+    if (rect) {
+      DOM_CACHE.boundingRects.set(element, rect);
+    }
+    return rect;
+  }
+
+  /**
+   * Gets the cached computed style for an element.
+   *
+   * @param {HTMLElement} element - The element to get the computed style for.
+   * @returns {CSSStyleDeclaration | null} The cached computed style, or null if the element is not found.
+   */
+  function getCachedComputedStyle(element) {
+    if (!element) return null;
+
+    if (DOM_CACHE.computedStyles.has(element)) {
+      return DOM_CACHE.computedStyles.get(element);
+    }
+
+    const style = window.getComputedStyle(element);
+
+    if (style) {
+      DOM_CACHE.computedStyles.set(element, style);
+    }
+    return style;
+  }
+
+  /**
+   * Gets the cached client rects for an element.
+   *
+   * @param {HTMLElement} element - The element to get the client rects for.
+   * @returns {DOMRectList | null} The cached client rects, or null if the element is not found.
+   */
+  function getCachedClientRects(element) {
+    if (!element) return null;
+
+    if (DOM_CACHE.clientRects.has(element)) {
+      return DOM_CACHE.clientRects.get(element);
+    }
+
+    const rects = element.getClientRects();
+
+    if (rects) {
+      DOM_CACHE.clientRects.set(element, rects);
+    }
+    return rects;
+  }
+
+  /**
+   * Hash map of DOM nodes indexed by their highlight index.
+   *
+   * @type {Object<string, any>}
+   */
+  const DOM_HASH_MAP = {};
+
+  const ID = { current: startId };
+
+  const HIGHLIGHT_CONTAINER_ID = 'playwright-highlight-container';
+
+  function resetHighlightContainer(shouldShow) {
+    const existing = document.getElementById(HIGHLIGHT_CONTAINER_ID);
+    if (existing) {
+      existing.style.display = shouldShow ? 'block' : 'none';
+      while (existing.firstChild) {
+        existing.removeChild(existing.firstChild);
+      }
+    }
+    if (window._highlightCleanupFunctions && window._highlightCleanupFunctions.length) {
+      for (const fn of window._highlightCleanupFunctions) {
+        try {
+          fn();
+        } catch (err) {
+          // Ignore cleanup errors
+        }
+      }
+      window._highlightCleanupFunctions = [];
+    }
+  }
+
+  // Add a WeakMap cache for XPath strings
+  const xpathCache = new WeakMap();
+
+  resetHighlightContainer(showHighlightElements);
+
+  // // Initialize once and reuse
+  // const viewportObserver = new IntersectionObserver(
+  //   (entries) => {
+  //     entries.forEach(entry => {
+  //       elementVisibilityMap.set(entry.target, entry.isIntersecting);
+  //     });
+  //   },
+  //   { rootMargin: `${viewportExpansion}px` }
+  // );
+
+  /**
+   * Highlights an element in the DOM and returns the index of the next element.
+   *
+   * @param {HTMLElement} element - The element to highlight.
+   * @param {number} index - The index of the element.
+   * @param {HTMLElement | null} parentIframe - The parent iframe node.
+   * @returns {number} The index of the next element.
+   */
+  function highlightElement(element, index, parentIframe = null) {
+    if (!element) return index;
+
+    const overlays = [];
+    /**
+     * @type {HTMLElement | null}
+     */
+    let label = null;
+    let labelWidth = 20;
+    let labelHeight = 16;
+    let cleanupFn = null;
+
+    try {
+      // Create or get highlight container
+      let container = document.getElementById(HIGHLIGHT_CONTAINER_ID);
+      if (!container) {
+        container = document.createElement('div');
+        container.id = HIGHLIGHT_CONTAINER_ID;
+        container.style.position = 'fixed';
+        container.style.pointerEvents = 'none';
+        container.style.top = '0';
+        container.style.left = '0';
+        container.style.width = '100%';
+        container.style.height = '100%';
+        // Use the maximum valid value in zIndex to ensure the element is not blocked by overlapping elements.
+        container.style.zIndex = '2147483647';
+        container.style.backgroundColor = 'transparent';
+        // Show or hide the container based on the showHighlightElements flag
+        container.style.display = showHighlightElements ? 'block' : 'none';
+        document.body.appendChild(container);
+      }
+
+      // Get element client rects
+      const rects = element.getClientRects(); // Use getClientRects()
+
+      if (!rects || rects.length === 0) return index; // Exit if no rects
+
+      // Generate a color based on the index
+      const colors = [
+        '#FF0000',
+        '#00FF00',
+        '#0000FF',
+        '#FFA500',
+        '#800080',
+        '#008080',
+        '#FF69B4',
+        '#4B0082',
+        '#FF4500',
+        '#2E8B57',
+        '#DC143C',
+        '#4682B4',
+      ];
+      const colorIndex = index % colors.length;
+      const baseColor = colors[colorIndex];
+      const backgroundColor = baseColor + '1A'; // 10% opacity version of the color
+
+      // Get iframe offset if necessary
+      let iframeOffset = { x: 0, y: 0 };
+      if (parentIframe) {
+        const iframeRect = parentIframe.getBoundingClientRect(); // Keep getBoundingClientRect for iframe offset
+        iframeOffset.x = iframeRect.left;
+        iframeOffset.y = iframeRect.top;
+      }
+
+      // Create fragment to hold overlay elements
+      const fragment = document.createDocumentFragment();
+
+      // Create highlight overlays for each client rect
+      for (const rect of rects) {
+        if (rect.width === 0 || rect.height === 0) continue; // Skip empty rects
+
+        const overlay = document.createElement('div');
+        overlay.style.position = 'fixed';
+        overlay.style.border = `2px solid ${baseColor}`;
+        overlay.style.backgroundColor = backgroundColor;
+        overlay.style.pointerEvents = 'none';
+        overlay.style.boxSizing = 'border-box';
+
+        const top = rect.top + iframeOffset.y;
+        const left = rect.left + iframeOffset.x;
+
+        overlay.style.top = `${top}px`;
+        overlay.style.left = `${left}px`;
+        overlay.style.width = `${rect.width}px`;
+        overlay.style.height = `${rect.height}px`;
+
+        fragment.appendChild(overlay);
+        overlays.push({ element: overlay, initialRect: rect }); // Store overlay and its rect
+      }
+
+      // Create and position a single label relative to the first rect
+      const firstRect = rects[0];
+      label = document.createElement('div');
+      label.className = 'playwright-highlight-label';
+      label.style.position = 'fixed';
+      label.style.background = baseColor;
+      label.style.color = 'white';
+      label.style.padding = '1px 4px';
+      label.style.borderRadius = '4px';
+      label.style.fontSize = `${Math.min(12, Math.max(8, firstRect.height / 2))}px`;
+      label.textContent = index.toString();
+
+      labelWidth = label.offsetWidth > 0 ? label.offsetWidth : labelWidth; // Update actual width if possible
+      labelHeight = label.offsetHeight > 0 ? label.offsetHeight : labelHeight; // Update actual height if possible
+
+      const firstRectTop = firstRect.top + iframeOffset.y;
+      const firstRectLeft = firstRect.left + iframeOffset.x;
+
+      let labelTop = firstRectTop + 2;
+      let labelLeft = firstRectLeft + firstRect.width - labelWidth - 2;
+
+      // Adjust label position if first rect is too small
+      if (firstRect.width < labelWidth + 4 || firstRect.height < labelHeight + 4) {
+        labelTop = firstRectTop - labelHeight - 2;
+        labelLeft = firstRectLeft + firstRect.width - labelWidth; // Align with right edge
+        if (labelLeft < iframeOffset.x) labelLeft = firstRectLeft; // Prevent going off-left
+      }
+
+      // Ensure label stays within viewport bounds slightly better
+      labelTop = Math.max(0, Math.min(labelTop, window.innerHeight - labelHeight));
+      labelLeft = Math.max(0, Math.min(labelLeft, window.innerWidth - labelWidth));
+
+      label.style.top = `${labelTop}px`;
+      label.style.left = `${labelLeft}px`;
+
+      fragment.appendChild(label);
+
+      // Update positions on scroll/resize
+      const updatePositions = () => {
+        const newRects = element.getClientRects(); // Get fresh rects
+        let newIframeOffset = { x: 0, y: 0 };
+
+        if (parentIframe) {
+          const iframeRect = parentIframe.getBoundingClientRect(); // Keep getBoundingClientRect for iframe
+          newIframeOffset.x = iframeRect.left;
+          newIframeOffset.y = iframeRect.top;
+        }
+
+        // Update each overlay
+        overlays.forEach((overlayData, i) => {
+          if (i < newRects.length) {
+            // Check if rect still exists
+            const newRect = newRects[i];
+            const newTop = newRect.top + newIframeOffset.y;
+            const newLeft = newRect.left + newIframeOffset.x;
+
+            overlayData.element.style.top = `${newTop}px`;
+            overlayData.element.style.left = `${newLeft}px`;
+            overlayData.element.style.width = `${newRect.width}px`;
+            overlayData.element.style.height = `${newRect.height}px`;
+            overlayData.element.style.display = newRect.width === 0 || newRect.height === 0 ? 'none' : 'block';
+          } else {
+            // If fewer rects now, hide extra overlays
+            overlayData.element.style.display = 'none';
+          }
+        });
+
+        // If there are fewer new rects than overlays, hide the extras
+        if (newRects.length < overlays.length) {
+          for (let i = newRects.length; i < overlays.length; i++) {
+            overlays[i].element.style.display = 'none';
+          }
+        }
+
+        // Update label position based on the first new rect
+        if (label && newRects.length > 0) {
+          const firstNewRect = newRects[0];
+          const firstNewRectTop = firstNewRect.top + newIframeOffset.y;
+          const firstNewRectLeft = firstNewRect.left + newIframeOffset.x;
+
+          let newLabelTop = firstNewRectTop + 2;
+          let newLabelLeft = firstNewRectLeft + firstNewRect.width - labelWidth - 2;
+
+          if (firstNewRect.width < labelWidth + 4 || firstNewRect.height < labelHeight + 4) {
+            newLabelTop = firstNewRectTop - labelHeight - 2;
+            newLabelLeft = firstNewRectLeft + firstNewRect.width - labelWidth;
+            if (newLabelLeft < newIframeOffset.x) newLabelLeft = firstNewRectLeft;
+          }
+
+          // Ensure label stays within viewport bounds
+          newLabelTop = Math.max(0, Math.min(newLabelTop, window.innerHeight - labelHeight));
+          newLabelLeft = Math.max(0, Math.min(newLabelLeft, window.innerWidth - labelWidth));
+
+          label.style.top = `${newLabelTop}px`;
+          label.style.left = `${newLabelLeft}px`;
+          label.style.display = 'block';
+        } else if (label) {
+          // Hide label if element has no rects anymore
+          label.style.display = 'none';
+        }
+      };
+
+      const throttleFunction = (func, delay) => {
+        let lastCall = 0;
+        return (...args) => {
+          const now = performance.now();
+          if (now - lastCall < delay) return;
+          lastCall = now;
+          return func(...args);
+        };
+      };
+
+      const throttledUpdatePositions = throttleFunction(updatePositions, 16); // ~60fps
+      window.addEventListener('scroll', throttledUpdatePositions, true);
+      window.addEventListener('resize', throttledUpdatePositions);
+
+      // Add cleanup function
+      cleanupFn = () => {
+        window.removeEventListener('scroll', throttledUpdatePositions, true);
+        window.removeEventListener('resize', throttledUpdatePositions);
+        // Remove overlay elements if needed
+        overlays.forEach(overlay => overlay.element.remove());
+        if (label) label.remove();
+      };
+
+      // Then add fragment to container in one operation
+      container.appendChild(fragment);
+
+      return index + 1;
+    } finally {
+      // Store cleanup function for later use
+      if (cleanupFn) {
+        // Keep a reference to cleanup functions in a global array
+        (window._highlightCleanupFunctions = window._highlightCleanupFunctions || []).push(cleanupFn);
+      }
+    }
+  }
+
+  // // Add this function to perform cleanup when needed
+  // function cleanupHighlights() {
+  //   if (window._highlightCleanupFunctions && window._highlightCleanupFunctions.length) {
+  //     window._highlightCleanupFunctions.forEach(fn => fn());
+  //     window._highlightCleanupFunctions = [];
+  //   }
+
+  //   // Also remove the container
+  //   const container = document.getElementById(HIGHLIGHT_CONTAINER_ID);
+  //   if (container) container.remove();
+  // }
+
+  /**
+   * Gets the position of an element in its parent.
+   *
+   * @param {HTMLElement} currentElement - The element to get the position for.
+   * @returns {number} The position of the element in its parent.
+   */
+  function getElementPosition(currentElement) {
+    if (!currentElement.parentElement) {
+      return 0; // No parent means no siblings
+    }
+
+    const tagName = currentElement.nodeName.toLowerCase();
+
+    const siblings = Array.from(currentElement.parentElement.children).filter(
+      sib => sib.nodeName.toLowerCase() === tagName,
+    );
+
+    if (siblings.length === 1) {
+      return 0; // Only element of its type
+    }
+
+    const index = siblings.indexOf(currentElement) + 1; // 1-based index
+    return index;
+  }
+
+  function getXPathTree(element, stopAtBoundary = true) {
+    if (xpathCache.has(element)) return xpathCache.get(element);
+
+    const segments = [];
+    let currentElement = element;
+
+    while (currentElement && currentElement.nodeType === Node.ELEMENT_NODE) {
+      // Stop if we hit a shadow root or iframe
+      if (
+        stopAtBoundary &&
+        (currentElement.parentNode instanceof ShadowRoot || currentElement.parentNode instanceof HTMLIFrameElement)
+      ) {
+        break;
+      }
+
+      const position = getElementPosition(currentElement);
+      const tagName = currentElement.nodeName.toLowerCase();
+      const xpathIndex = position > 0 ? `[${position}]` : '';
+      segments.unshift(`${tagName}${xpathIndex}`);
+
+      currentElement = currentElement.parentNode;
+    }
+
+    const result = segments.join('/');
+    xpathCache.set(element, result);
+    return result;
+  }
+
+  /**
+   * Checks if a text node is visible.
+   *
+   * @param {Text} textNode - The text node to check.
+   * @returns {boolean} Whether the text node is visible.
+   */
+  function isTextNodeVisible(textNode) {
+    try {
+      // Special case: when viewportExpansion is -1, consider all text nodes as visible
+      if (viewportExpansion === -1) {
+        // Still check parent visibility for basic filtering
+        const parentElement = textNode.parentElement;
+        if (!parentElement) return false;
+
+        try {
+          return parentElement.checkVisibility({
+            checkOpacity: true,
+            checkVisibilityCSS: true,
+          });
+        } catch (e) {
+          // Fallback if checkVisibility is not supported
+          const style = window.getComputedStyle(parentElement);
+          return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+        }
+      }
+
+      const range = document.createRange();
+      range.selectNodeContents(textNode);
+      const rects = range.getClientRects(); // Use getClientRects for Range
+
+      if (!rects || rects.length === 0) {
+        return false;
+      }
+
+      let isAnyRectVisible = false;
+      let isAnyRectInViewport = false;
+
+      for (const rect of rects) {
+        // Check size
+        if (rect.width > 0 && rect.height > 0) {
+          isAnyRectVisible = true;
+
+          // Viewport check for this rect
+          if (
+            !(
+              rect.bottom < -viewportExpansion ||
+              rect.top > window.innerHeight + viewportExpansion ||
+              rect.right < -viewportExpansion ||
+              rect.left > window.innerWidth + viewportExpansion
+            )
+          ) {
+            isAnyRectInViewport = true;
+            break; // Found a visible rect in viewport, no need to check others
+          }
+        }
+      }
+
+      if (!isAnyRectVisible || !isAnyRectInViewport) {
+        return false;
+      }
+
+      // Check parent visibility
+      const parentElement = textNode.parentElement;
+      if (!parentElement) return false;
+
+      try {
+        return parentElement.checkVisibility({
+          checkOpacity: true,
+          checkVisibilityCSS: true,
+        });
+      } catch (e) {
+        // Fallback if checkVisibility is not supported
+        const style = window.getComputedStyle(parentElement);
+        return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+      }
+    } catch (e) {
+      console.warn('Error checking text node visibility:', e);
+      return false;
+    }
+  }
+
+  /**
+   * Checks if an element is accepted.
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @returns {boolean} Whether the element is accepted.
+   */
+  function isElementAccepted(element) {
+    if (!element || !element.tagName) return false;
+
+    // Always accept body and common container elements
+    const alwaysAccept = new Set(['body', 'div', 'main', 'article', 'section', 'nav', 'header', 'footer']);
+    const tagName = element.tagName.toLowerCase();
+
+    if (alwaysAccept.has(tagName)) return true;
+
+    const leafElementDenyList = new Set(['svg', 'script', 'style', 'link', 'meta', 'noscript', 'template']);
+
+    return !leafElementDenyList.has(tagName);
+  }
+
+  /**
+   * Checks if an element is visible.
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @returns {boolean} Whether the element is visible.
+   */
+  function isElementVisible(element) {
+    const style = getCachedComputedStyle(element);
+    return (
+      element.offsetWidth > 0 && element.offsetHeight > 0 && style?.visibility !== 'hidden' && style?.display !== 'none'
+    );
+  }
+
+  /**
+   * Checks if an element is interactive.
+   *
+   * lots of comments, and uncommented code - to show the logic of what we already tried
+   *
+   * One of the things we tried at the beginning was also to use event listeners, and other fancy class, style stuff -> what actually worked best was just combining most things with computed cursor style :)
+   *
+   * @param {HTMLElement} element - The element to check.
+   */
+  function isInteractiveElement(element) {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+      return false;
+    }
+
+    // Cache the tagName and style lookups
+    const tagName = element.tagName.toLowerCase();
+    const style = getCachedComputedStyle(element);
+
+    // Define interactive cursors
+    const interactiveCursors = new Set([
+      'pointer', // Link/clickable elements
+      'move', // Movable elements
+      'text', // Text selection
+      'grab', // Grabbable elements
+      'grabbing', // Currently grabbing
+      'cell', // Table cell selection
+      'copy', // Copy operation
+      'alias', // Alias creation
+      'all-scroll', // Scrollable content
+      'col-resize', // Column resize
+      'context-menu', // Context menu available
+      'crosshair', // Precise selection
+      'e-resize', // East resize
+      'ew-resize', // East-west resize
+      'help', // Help available
+      'n-resize', // North resize
+      'ne-resize', // Northeast resize
+      'nesw-resize', // Northeast-southwest resize
+      'ns-resize', // North-south resize
+      'nw-resize', // Northwest resize
+      'nwse-resize', // Northwest-southeast resize
+      'row-resize', // Row resize
+      's-resize', // South resize
+      'se-resize', // Southeast resize
+      'sw-resize', // Southwest resize
+      'vertical-text', // Vertical text selection
+      'w-resize', // West resize
+      'zoom-in', // Zoom in
+      'zoom-out', // Zoom out
+    ]);
+
+    // Define non-interactive cursors
+    const nonInteractiveCursors = new Set([
+      'not-allowed', // Action not allowed
+      'no-drop', // Drop not allowed
+      'wait', // Processing
+      'progress', // In progress
+      'initial', // Initial value
+      'inherit', // Inherited value
+      //? Let's just include all potentially clickable elements that are not specifically blocked
+      // 'none',        // No cursor
+      // 'default',     // Default cursor
+      // 'auto',        // Browser default
+    ]);
+
+    /**
+     * Checks if an element has an interactive pointer.
+     *
+     * @param {HTMLElement} element - The element to check.
+     * @returns {boolean} Whether the element has an interactive pointer.
+     */
+    function doesElementHaveInteractivePointer(element) {
+      if (element.tagName.toLowerCase() === 'html') return false;
+
+      if (style?.cursor && interactiveCursors.has(style.cursor)) return true;
+
+      return false;
+    }
+
+    let isInteractiveCursor = doesElementHaveInteractivePointer(element);
+
+    // Genius fix for almost all interactive elements
+    if (isInteractiveCursor) {
+      return true;
+    }
+
+    const interactiveElements = new Set([
+      'a', // Links
+      'button', // Buttons
+      'input', // All input types (text, checkbox, radio, etc.)
+      'select', // Dropdown menus
+      'textarea', // Text areas
+      'details', // Expandable details
+      'summary', // Summary element (clickable part of details)
+      'label', // Form labels (often clickable)
+      'option', // Select options
+      'optgroup', // Option groups
+      'fieldset', // Form fieldsets (can be interactive with legend)
+      'legend', // Fieldset legends
+    ]);
+
+    // Define explicit disable attributes and properties
+    const explicitDisableTags = new Set([
+      'disabled', // Standard disabled attribute
+      // 'aria-disabled',      // ARIA disabled state
+      'readonly', // Read-only state
+      // 'aria-readonly',     // ARIA read-only state
+      // 'aria-hidden',       // Hidden from accessibility
+      // 'hidden',            // Hidden attribute
+      // 'inert',             // Inert attribute
+      // 'aria-inert',        // ARIA inert state
+      // 'tabindex="-1"',     // Removed from tab order
+      // 'aria-hidden="true"' // Hidden from screen readers
+    ]);
+
+    // handle inputs, select, checkbox, radio, textarea, button and make sure they are not cursor style disabled/not-allowed
+    if (interactiveElements.has(tagName)) {
+      // Check for non-interactive cursor
+      if (style?.cursor && nonInteractiveCursors.has(style.cursor)) {
+        return false;
+      }
+
+      // Check for explicit disable attributes
+      for (const disableTag of explicitDisableTags) {
+        if (
+          element.hasAttribute(disableTag) ||
+          element.getAttribute(disableTag) === 'true' ||
+          element.getAttribute(disableTag) === ''
+        ) {
+          return false;
+        }
+      }
+
+      // Check for disabled property on form elements
+      if (element.disabled) {
+        return false;
+      }
+
+      // Check for readonly property on form elements
+      if (element.readOnly) {
+        return false;
+      }
+
+      // Check for inert property
+      if (element.inert) {
+        return false;
+      }
+
+      return true;
+    }
+
+    const role = element.getAttribute('role');
+    const ariaRole = element.getAttribute('aria-role');
+
+    // Check for contenteditable attribute
+    if (element.getAttribute('contenteditable') === 'true' || element.isContentEditable) {
+      return true;
+    }
+
+    // Added enhancement to capture dropdown interactive elements
+    if (
+      element.classList &&
+      (element.classList.contains('button') ||
+        element.classList.contains('dropdown-toggle') ||
+        element.getAttribute('data-index') ||
+        element.getAttribute('data-toggle') === 'dropdown' ||
+        element.getAttribute('aria-haspopup') === 'true')
+    ) {
+      return true;
+    }
+
+    const interactiveRoles = new Set([
+      'button', // Directly clickable element
+      // 'link',            // Clickable link
+      'menu', // Menu container (ARIA menus)
+      'menubar', // Menu bar container
+      'menuitem', // Clickable menu item
+      'menuitemradio', // Radio-style menu item (selectable)
+      'menuitemcheckbox', // Checkbox-style menu item (toggleable)
+      'radio', // Radio button (selectable)
+      'checkbox', // Checkbox (toggleable)
+      'tab', // Tab (clickable to switch content)
+      'switch', // Toggle switch (clickable to change state)
+      'slider', // Slider control (draggable)
+      'spinbutton', // Number input with up/down controls
+      'combobox', // Dropdown with text input
+      'searchbox', // Search input field
+      'textbox', // Text input field
+      'listbox', // Selectable list
+      'option', // Selectable option in a list
+      'scrollbar', // Scrollable control
+    ]);
+
+    // Basic role/attribute checks
+    const hasInteractiveRole =
+      interactiveElements.has(tagName) ||
+      (role && interactiveRoles.has(role)) ||
+      (ariaRole && interactiveRoles.has(ariaRole));
+
+    if (hasInteractiveRole) return true;
+
+    // check whether element has event listeners by window.getEventListeners
+    try {
+      if (typeof getEventListeners === 'function') {
+        const listeners = getEventListeners(element);
+        const mouseEvents = ['click', 'mousedown', 'mouseup', 'dblclick'];
+        for (const eventType of mouseEvents) {
+          if (listeners[eventType] && listeners[eventType].length > 0) {
+            return true; // Found a mouse interaction listener
+          }
+        }
+      }
+
+      const getEventListenersForNode =
+        element?.ownerDocument?.defaultView?.getEventListenersForNode || window.getEventListenersForNode;
+      if (typeof getEventListenersForNode === 'function') {
+        const listeners = getEventListenersForNode(element);
+        const interactionEvents = [
+          'click',
+          'mousedown',
+          'mouseup',
+          'keydown',
+          'keyup',
+          'submit',
+          'change',
+          'input',
+          'focus',
+          'blur',
+        ];
+        for (const eventType of interactionEvents) {
+          for (const listener of listeners) {
+            if (listener.type === eventType) {
+              return true; // Found a common interaction listener
+            }
+          }
+        }
+      }
+      // Fallback: Check common event attributes if getEventListeners is not available (getEventListeners doesn't work in page.evaluate context)
+      const commonMouseAttrs = ['onclick', 'onmousedown', 'onmouseup', 'ondblclick'];
+      for (const attr of commonMouseAttrs) {
+        if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
+          return true;
+        }
+      }
+    } catch (e) {
+      // console.warn(`Could not check event listeners for ${element.tagName}:`, e);
+      // If checking listeners fails, rely on other checks
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if an element is the topmost element at its position.
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @returns {boolean} Whether the element is the topmost element at its position.
+   */
+  function isTopElement(element) {
+    // Special case: when viewportExpansion is -1, consider all elements as "top" elements
+    if (viewportExpansion === -1) {
+      return true;
+    }
+
+    const rects = getCachedClientRects(element); // Replace element.getClientRects()
+
+    if (!rects || rects.length === 0) {
+      return false; // No geometry, cannot be top
+    }
+
+    let isAnyRectInViewport = false;
+    for (const rect of rects) {
+      // Use the same logic as isInExpandedViewport check
+      if (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        !(
+          // Only check non-empty rects
+          (
+            rect.bottom < -viewportExpansion ||
+            rect.top > window.innerHeight + viewportExpansion ||
+            rect.right < -viewportExpansion ||
+            rect.left > window.innerWidth + viewportExpansion
+          )
+        )
+      ) {
+        isAnyRectInViewport = true;
+        break;
+      }
+    }
+
+    if (!isAnyRectInViewport) {
+      return false; // All rects are outside the viewport area
+    }
+
+    // Find the correct document context and root element
+    let doc = element.ownerDocument;
+
+    // If we're in an iframe, elements are considered top by default
+    if (doc !== window.document) {
+      return true;
+    }
+
+    // For shadow DOM, we need to check within its own root context
+    const shadowRoot = element.getRootNode();
+    if (shadowRoot instanceof ShadowRoot) {
+      const centerX = rects[Math.floor(rects.length / 2)].left + rects[Math.floor(rects.length / 2)].width / 2;
+      const centerY = rects[Math.floor(rects.length / 2)].top + rects[Math.floor(rects.length / 2)].height / 2;
+
+      try {
+        const topEl = shadowRoot.elementFromPoint(centerX, centerY);
+        if (!topEl) return false;
+
+        let current = topEl;
+        while (current && current !== shadowRoot) {
+          if (current === element) return true;
+          current = current.parentElement;
+        }
+        return false;
+      } catch (e) {
+        return true;
+      }
+    }
+
+    const margin = 5;
+    const rect = rects[Math.floor(rects.length / 2)];
+
+    // For elements in viewport, check if they're topmost. Do the check in the
+    // center of the element and at the corners to ensure we catch more cases.
+    const checkPoints = [
+      // Initially only this was used, but it was not enough
+      { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+      { x: rect.left + margin, y: rect.top + margin }, // top left
+      // { x: rect.right - margin, y: rect.top + margin },    // top right
+      // { x: rect.left + margin, y: rect.bottom - margin },  // bottom left
+      { x: rect.right - margin, y: rect.bottom - margin }, // bottom right
+    ];
+
+    return checkPoints.some(({ x, y }) => {
+      try {
+        const topEl = document.elementFromPoint(x, y);
+        if (!topEl) return false;
+
+        let current = topEl;
+        while (current && current !== document.documentElement) {
+          if (current === element) return true;
+          current = current.parentElement;
+        }
+        return false;
+      } catch (e) {
+        return true;
+      }
+    });
+  }
+
+  /**
+   * Checks if an element is within the expanded viewport.
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @param {number} viewportExpansion - The viewport expansion.
+   * @returns {boolean} Whether the element is within the expanded viewport.
+   */
+  function isInExpandedViewport(element, viewportExpansion) {
+    if (viewportExpansion === -1) {
+      return true;
+    }
+
+    const rects = element.getClientRects(); // Use getClientRects
+
+    if (!rects || rects.length === 0) {
+      // Fallback to getBoundingClientRect if getClientRects is empty,
+      // useful for elements like <svg> that might not have client rects but have a bounding box.
+      const boundingRect = getCachedBoundingRect(element);
+      if (!boundingRect || boundingRect.width === 0 || boundingRect.height === 0) {
+        return false;
+      }
+      return !(
+        boundingRect.bottom < -viewportExpansion ||
+        boundingRect.top > window.innerHeight + viewportExpansion ||
+        boundingRect.right < -viewportExpansion ||
+        boundingRect.left > window.innerWidth + viewportExpansion
+      );
+    }
+
+    // Check if *any* client rect is within the viewport
+    for (const rect of rects) {
+      if (rect.width === 0 || rect.height === 0) continue; // Skip empty rects
+
+      if (
+        !(
+          rect.bottom < -viewportExpansion ||
+          rect.top > window.innerHeight + viewportExpansion ||
+          rect.right < -viewportExpansion ||
+          rect.left > window.innerWidth + viewportExpansion
+        )
+      ) {
+        return true; // Found at least one rect in the viewport
+      }
+    }
+
+    return false; // No rects were found in the viewport
+  }
+
+  // /**
+  //  * Gets the effective scroll of an element.
+  //  *
+  //  * @param {HTMLElement} element - The element to get the effective scroll for.
+  //  * @returns {Object} The effective scroll of the element.
+  //  */
+  // function getEffectiveScroll(element) {
+  //   let currentEl = element;
+  //   let scrollX = 0;
+  //   let scrollY = 0;
+
+  //   while (currentEl && currentEl !== document.documentElement) {
+  //     if (currentEl.scrollLeft || currentEl.scrollTop) {
+  //       scrollX += currentEl.scrollLeft;
+  //       scrollY += currentEl.scrollTop;
+  //     }
+  //     currentEl = currentEl.parentElement;
+  //   }
+
+  //   scrollX += window.scrollX;
+  //   scrollY += window.scrollY;
+
+  //   return { scrollX, scrollY };
+  // }
+
+  /**
+   * Checks if an element is an interactive candidate.
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @returns {boolean} Whether the element is an interactive candidate.
+   */
+  function isInteractiveCandidate(element) {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+
+    const tagName = element.tagName.toLowerCase();
+
+    // Fast-path for common interactive elements
+    const interactiveElements = new Set(['a', 'button', 'input', 'select', 'textarea', 'details', 'summary', 'label']);
+
+    if (interactiveElements.has(tagName)) return true;
+
+    // Quick attribute checks without getting full lists
+    const hasQuickInteractiveAttr =
+      element.hasAttribute('onclick') ||
+      element.hasAttribute('role') ||
+      element.hasAttribute('tabindex') ||
+      element.hasAttribute('aria-') ||
+      element.hasAttribute('data-action') ||
+      element.getAttribute('contenteditable') === 'true';
+
+    return hasQuickInteractiveAttr;
+  }
+
+  // --- Define constants for distinct interaction check ---
+  const DISTINCT_INTERACTIVE_TAGS = new Set([
+    'a',
+    'button',
+    'input',
+    'select',
+    'textarea',
+    'summary',
+    'details',
+    'label',
+    'option',
+  ]);
+  const INTERACTIVE_ROLES = new Set([
+    'button',
+    'link',
+    'menuitem',
+    'menuitemradio',
+    'menuitemcheckbox',
+    'radio',
+    'checkbox',
+    'tab',
+    'switch',
+    'slider',
+    'spinbutton',
+    'combobox',
+    'searchbox',
+    'textbox',
+    'listbox',
+    'option',
+    'scrollbar',
+  ]);
+
+  /**
+   * Heuristically determines if an element should be considered as independently interactive,
+   * even if it's nested inside another interactive container.
+   *
+   * This function helps detect deeply nested actionable elements (e.g., menu items within a button)
+   * that may not be picked up by strict interactivity checks.
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @returns {boolean} Whether the element is heuristically interactive.
+   */
+  function isHeuristicallyInteractive(element) {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+
+    // Skip non-visible elements early for performance
+    if (!isElementVisible(element)) return false;
+
+    // Check for common attributes that often indicate interactivity
+    const hasInteractiveAttributes =
+      element.hasAttribute('role') ||
+      element.hasAttribute('tabindex') ||
+      element.hasAttribute('onclick') ||
+      typeof element.onclick === 'function';
+
+    // Check for semantic class names suggesting interactivity
+    const hasInteractiveClass = /\b(btn|clickable|menu|item|entry|link)\b/i.test(element.className || '');
+
+    // Determine whether the element is inside a known interactive container
+    const isInKnownContainer = Boolean(element.closest('button,a,[role="button"],.menu,.dropdown,.list,.toolbar'));
+
+    // Ensure the element has at least one visible child (to avoid marking empty wrappers)
+    const hasVisibleChildren = [...element.children].some(isElementVisible);
+
+    // Avoid highlighting elements whose parent is <body> (top-level wrappers)
+    const isParentBody = element.parentElement && element.parentElement.isSameNode(document.body);
+
+    return (
+      (isInteractiveElement(element) || hasInteractiveAttributes || hasInteractiveClass) &&
+      hasVisibleChildren &&
+      isInKnownContainer &&
+      !isParentBody
+    );
+  }
+
+  /**
+   * Checks if an element likely represents a distinct interaction
+   * separate from its parent (if the parent is also interactive).
+   *
+   * @param {HTMLElement} element - The element to check.
+   * @returns {boolean} Whether the element is a distinct interaction.
+   */
+  function isElementDistinctInteraction(element) {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+      return false;
+    }
+
+    const tagName = element.tagName.toLowerCase();
+    const role = element.getAttribute('role');
+
+    // Check if it's an iframe - always distinct boundary
+    if (tagName === 'iframe') {
+      return true;
+    }
+
+    // Check tag name
+    if (DISTINCT_INTERACTIVE_TAGS.has(tagName)) {
+      return true;
+    }
+    // Check interactive roles
+    if (role && INTERACTIVE_ROLES.has(role)) {
+      return true;
+    }
+    // Check contenteditable
+    if (element.isContentEditable || element.getAttribute('contenteditable') === 'true') {
+      return true;
+    }
+    // Check for common testing/automation attributes
+    if (element.hasAttribute('data-testid') || element.hasAttribute('data-cy') || element.hasAttribute('data-test')) {
+      return true;
+    }
+    // Check for explicit onclick handler (attribute or property)
+    if (element.hasAttribute('onclick') || typeof element.onclick === 'function') {
+      return true;
+    }
+
+    // return false
+
+    // Check for other common interaction event listeners
+    try {
+      const getEventListenersForNode =
+        element?.ownerDocument?.defaultView?.getEventListenersForNode || window.getEventListenersForNode;
+      if (typeof getEventListenersForNode === 'function') {
+        const listeners = getEventListenersForNode(element);
+        const interactionEvents = [
+          'click',
+          'mousedown',
+          'mouseup',
+          'keydown',
+          'keyup',
+          'submit',
+          'change',
+          'input',
+          'focus',
+          'blur',
+        ];
+        for (const eventType of interactionEvents) {
+          for (const listener of listeners) {
+            if (listener.type === eventType) {
+              return true; // Found a common interaction listener
+            }
+          }
+        }
+      }
+      // Fallback: Check common event attributes if getEventListeners is not available (getEventListenersForNode doesn't work in page.evaluate context)
+      const commonEventAttrs = [
+        'onmousedown',
+        'onmouseup',
+        'onkeydown',
+        'onkeyup',
+        'onsubmit',
+        'onchange',
+        'oninput',
+        'onfocus',
+        'onblur',
+      ];
+      if (commonEventAttrs.some(attr => element.hasAttribute(attr))) {
+        return true;
+      }
+    } catch (e) {
+      // console.warn(`Could not check event listeners for ${element.tagName}:`, e);
+      // If checking listeners fails, rely on other checks
+    }
+
+    // if the element is not strictly interactive but appears clickable based on heuristic signals
+    if (isHeuristicallyInteractive(element)) {
+      return true;
+    }
+
+    // Default to false: if it's interactive but doesn't match above,
+    // assume it triggers the same action as the parent.
+    return false;
+  }
+  // --- End distinct interaction check ---
+
+  /**
+   * Handles the logic for deciding whether to highlight an element and performing the highlight.
+   * @param {
+    {
+        tagName: string;
+        attributes: Record<string, string>;
+        xpath: any;
+        children: never[];
+        isVisible?: boolean;
+        isTopElement?: boolean;
+        isInteractive?: boolean;
+        isInViewport?: boolean;
+        highlightIndex?: number;
+        shadowRoot?: boolean;
+   }} nodeData - The node data object.
+   * @param {HTMLElement} node - The node to highlight.
+   * @param {HTMLElement | null} parentIframe - The parent iframe node.
+   * @param {boolean} isParentHighlighted - Whether the parent node is highlighted.
+   * @returns {boolean} Whether the element was highlighted.
+   */
+  function handleHighlighting(nodeData, node, parentIframe, isParentHighlighted) {
+    if (!nodeData.isInteractive) return false; // Not interactive, definitely don't highlight
+
+    let shouldHighlight = false;
+    if (!isParentHighlighted) {
+      // Parent wasn't highlighted, this interactive node can be highlighted.
+      shouldHighlight = true;
+    } else {
+      // Parent *was* highlighted. Only highlight this node if it represents a distinct interaction.
+      if (isElementDistinctInteraction(node)) {
+        shouldHighlight = true;
+      } else {
+        // console.log(`Skipping highlight for ${nodeData.tagName} (parent highlighted)`);
+        shouldHighlight = false;
+      }
+    }
+
+    if (shouldHighlight) {
+      // Check viewport status before assigning index and highlighting
+      nodeData.isInViewport = isInExpandedViewport(node, viewportExpansion);
+
+      // When viewportExpansion is -1, all interactive elements should get a highlight index
+      // regardless of viewport status
+      if (nodeData.isInViewport || viewportExpansion === -1) {
+        nodeData.highlightIndex = highlightIndex++;
+
+        if (doHighlightElements) {
+          if (focusHighlightIndex >= 0) {
+            if (focusHighlightIndex === nodeData.highlightIndex) {
+              highlightElement(node, nodeData.highlightIndex, parentIframe);
+            }
+          } else {
+            highlightElement(node, nodeData.highlightIndex, parentIframe);
+          }
+          return true; // Successfully highlighted
+        }
+      } else {
+        // console.log(`Skipping highlight for ${nodeData.tagName} (outside viewport)`);
+      }
+    }
+
+    return false; // Did not highlight
+  }
+
+  /**
+   * Creates a node data object for a given node and its descendants.
+   *
+   * @param {HTMLElement} node - The node to process.
+   * @param {HTMLElement | null} parentIframe - The parent iframe node.
+   * @param {boolean} isParentHighlighted - Whether the parent node is highlighted.
+   * @returns {string | null} The ID of the node data object, or null if the node is not processed.
+   */
+  function buildDomTree(node, parentIframe = null, isParentHighlighted = false) {
+    // Fast rejection checks first
+    if (
+      !node ||
+      node.id === HIGHLIGHT_CONTAINER_ID ||
+      (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.TEXT_NODE)
+    ) {
+      return null;
+    }
+
+    if (!node || node.id === HIGHLIGHT_CONTAINER_ID) {
+      return null;
+    }
+
+    // Special handling for root node (body)
+    if (node === document.body) {
+      const nodeData = {
+        tagName: 'body',
+        attributes: {},
+        xpath: '/body',
+        children: [],
+      };
+
+      // Process children of body
+      for (const child of node.childNodes) {
+        const domElement = buildDomTree(child, parentIframe, false); // Body's children have no highlighted parent initially
+        if (domElement) nodeData.children.push(domElement);
+      }
+
+      const id = `${ID.current++}`;
+      DOM_HASH_MAP[id] = nodeData;
+      return id;
+    }
+
+    // Early bailout for non-element nodes except text
+    if (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.TEXT_NODE) {
+      return null;
+    }
+
+    // Process text nodes
+    if (node.nodeType === Node.TEXT_NODE) {
+      const textContent = node.textContent?.trim();
+      if (!textContent) {
+        return null;
+      }
+
+      // Only check visibility for text nodes that might be visible
+      const parentElement = node.parentElement;
+      if (!parentElement || parentElement.tagName.toLowerCase() === 'script') {
+        return null;
+      }
+
+      const id = `${ID.current++}`;
+      DOM_HASH_MAP[id] = {
+        type: 'TEXT_NODE',
+        text: textContent,
+        isVisible: isTextNodeVisible(node),
+      };
+      return id;
+    }
+
+    // Quick checks for element nodes
+    if (node.nodeType === Node.ELEMENT_NODE && !isElementAccepted(node)) {
+      return null;
+    }
+
+    // Early viewport check - only filter out elements clearly outside viewport
+    // The getBoundingClientRect() of the Shadow DOM host element may return width/height = 0
+    if (viewportExpansion !== -1 && !node.shadowRoot) {
+      const rect = getCachedBoundingRect(node); // Keep for initial quick check
+      const style = getCachedComputedStyle(node);
+
+      // Skip viewport check for fixed/sticky elements as they may appear anywhere
+      const isFixedOrSticky = style && (style.position === 'fixed' || style.position === 'sticky');
+
+      // Check if element has actual dimensions using offsetWidth/Height (quick check)
+      const hasSize = node.offsetWidth > 0 || node.offsetHeight > 0;
+
+      // Use getBoundingClientRect for the quick OUTSIDE check.
+      // isInExpandedViewport will do the more accurate check later if needed.
+      if (
+        !rect ||
+        (!isFixedOrSticky &&
+          !hasSize &&
+          (rect.bottom < -viewportExpansion ||
+            rect.top > window.innerHeight + viewportExpansion ||
+            rect.right < -viewportExpansion ||
+            rect.left > window.innerWidth + viewportExpansion))
+      ) {
+        // console.log("Skipping node outside viewport (quick check):", node.tagName, rect);
+        return null;
+      }
+    }
+
+    /**
+     * @type {
+      {
+          tagName: string;
+          attributes: Record<string, string | null>;
+          xpath: any;
+          children: never[];
+          isVisible?: boolean;
+          isTopElement?: boolean;
+          isInteractive?: boolean;
+          isInViewport?: boolean;
+          highlightIndex?: number;
+          shadowRoot?: boolean;
+      }
+    } nodeData - The node data object.
+     */
+    const nodeData = {
+      tagName: node.tagName.toLowerCase(),
+      attributes: {},
+      xpath: getXPathTree(node, true),
+      children: [],
+    };
+
+    // Capture live form/control state so the planner can reason about fields that are
+    // already filled versus ones that still need attention.
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const tagNameLower = nodeData.tagName;
+      const ariaRequired = node.getAttribute('aria-required');
+      if (ariaRequired && ariaRequired.toLowerCase() === 'true') {
+        nodeData.isRequired = true;
+      }
+
+      if (tagNameLower === 'input' || tagNameLower === 'textarea') {
+        try {
+          const value = node.value;
+          if (value !== undefined && value !== null && value !== '') {
+            nodeData.currentValue = String(value);
+          } else if (value === '') {
+            nodeData.currentValue = '';
+          }
+        } catch (err) {
+          // Ignore property access issues
+        }
+        if (tagNameLower === 'input') {
+          const inputType = (node.getAttribute('type') || node.type || 'text').toLowerCase();
+          nodeData.inputType = inputType;
+          if (inputType === 'checkbox' || inputType === 'radio') {
+            try {
+              nodeData.isChecked = Boolean(node.checked);
+            } catch (err) {
+              nodeData.isChecked = false;
+            }
+          }
+        }
+        if (node.required) {
+          nodeData.isRequired = true;
+        }
+      } else if (tagNameLower === 'select') {
+        try {
+          const selectedOptions = Array.from(node.selectedOptions || []);
+          if (selectedOptions.length) {
+            nodeData.selectedTexts = selectedOptions
+              .map((opt) => (opt.textContent || opt.label || '').trim())
+              .filter(Boolean);
+            nodeData.selectedValues = selectedOptions
+              .map((opt) => (opt.value ?? '').toString())
+              .filter((val) => val !== '');
+            const primary = selectedOptions[0];
+            if (primary) {
+              nodeData.currentValue = primary.value ?? '';
+            }
+          }
+        } catch (err) {
+          // Ignore option access issues
+        }
+        if (node.multiple) {
+          nodeData.isMultiple = true;
+        }
+        if (node.required) {
+          nodeData.isRequired = true;
+        }
+      }
+    }
+
+    // Get attributes for interactive elements or potential text containers
+    if (
+      isInteractiveCandidate(node) ||
+      node.tagName.toLowerCase() === 'iframe' ||
+      node.tagName.toLowerCase() === 'body'
+    ) {
+      const attributeNames = node.getAttributeNames?.() || [];
+      for (const name of attributeNames) {
+        const value = node.getAttribute(name);
+        nodeData.attributes[name] = value;
+      }
+    }
+
+    let nodeWasHighlighted = false;
+    // Perform visibility, interactivity, and highlighting checks
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      nodeData.isVisible = isElementVisible(node); // isElementVisible uses offsetWidth/Height, which is fine
+      if (nodeData.isVisible) {
+        nodeData.isTopElement = isTopElement(node);
+
+        // Special handling for ARIA menu containers - check interactivity even if not top element
+        const role = node.getAttribute('role');
+        const isMenuContainer = role === 'menu' || role === 'menubar' || role === 'listbox';
+
+        if (nodeData.isTopElement || isMenuContainer) {
+          nodeData.isInteractive = isInteractiveElement(node);
+          // Call the dedicated highlighting function
+          nodeWasHighlighted = handleHighlighting(nodeData, node, parentIframe, isParentHighlighted);
+        }
+      }
+    }
+
+    // Process children, with special handling for iframes and rich text editors
+    if (node.tagName) {
+      const tagName = node.tagName.toLowerCase();
+
+      // Handle iframes
+      if (tagName === 'iframe') {
+        const rect = getCachedBoundingRect(node);
+        nodeData.attributes['computedHeight'] = String(Math.ceil(rect.height));
+        nodeData.attributes['computedWidth'] = String(Math.ceil(rect.width));
+        try {
+          const iframeDoc = node.contentDocument || node.contentWindow?.document;
+          if (iframeDoc) {
+            for (const child of iframeDoc.childNodes) {
+              const domElement = buildDomTree(child, node, false);
+              if (domElement) nodeData.children.push(domElement);
+            }
+          }
+        } catch (e) {
+          nodeData.attributes['error'] = e.message;
+          console.warn('Unable to access iframe:', e);
+        }
+      }
+      // Handle rich text editors and contenteditable elements
+      else if (
+        node.isContentEditable ||
+        node.getAttribute('contenteditable') === 'true' ||
+        node.id === 'tinymce' ||
+        node.classList.contains('mce-content-body') ||
+        (tagName === 'body' && node.getAttribute('data-id')?.startsWith('mce_'))
+      ) {
+        // Process all child nodes to capture formatted text
+        for (const child of node.childNodes) {
+          const domElement = buildDomTree(child, parentIframe, nodeWasHighlighted);
+          if (domElement) nodeData.children.push(domElement);
+        }
+      } else {
+        // Handle shadow DOM
+        if (node.shadowRoot) {
+          nodeData.shadowRoot = true;
+          for (const child of node.shadowRoot.childNodes) {
+            const domElement = buildDomTree(child, parentIframe, nodeWasHighlighted);
+            if (domElement) nodeData.children.push(domElement);
+          }
+        }
+        // Handle regular elements
+        for (const child of node.childNodes) {
+          // Pass the highlighted status of the *current* node to its children
+          const passHighlightStatusToChild = nodeWasHighlighted || isParentHighlighted;
+          const domElement = buildDomTree(child, parentIframe, passHighlightStatusToChild);
+          if (domElement) nodeData.children.push(domElement);
+        }
+      }
+    }
+
+    // Skip empty anchor tags only if they have no dimensions and no children
+    if (nodeData.tagName === 'a' && nodeData.children.length === 0 && !nodeData.attributes.href) {
+      // Check if the anchor has actual dimensions
+      const rect = getCachedBoundingRect(node);
+      const hasSize = (rect && rect.width > 0 && rect.height > 0) || node.offsetWidth > 0 || node.offsetHeight > 0;
+
+      if (!hasSize) {
+        return null;
+      }
+    }
+
+    const id = `${ID.current++}`;
+    DOM_HASH_MAP[id] = nodeData;
+    return id;
+  }
+
+  const rootId = buildDomTree(document.body);
+
+  // Clear the cache before starting
+  DOM_CACHE.clearCache();
+
+  return { rootId, map: DOM_HASH_MAP };
+}
+
+if (typeof globalThis !== 'undefined') {
+  if (!globalThis.__zepraBuildDomTree) {
+    globalThis.__zepraBuildDomTree = buildDomTree;
+  }
+  if (!globalThis.__zepraBuildDomTreeModule) {
+    globalThis.__zepraBuildDomTreeModule = { buildDomTree };
+  }
+  if (!globalThis.buildDomTree) {
+    globalThis.buildDomTree = buildDomTree;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { buildDomTree };
+}


### PR DESCRIPTION
## Summary
- show a PLAN section in the chat using an English outline plus progress updates for each execution step
- execute planner-provided actions sequentially, including explicit DOM scans and OCR captures, while logging and handling failures
- expose complete action lists from the planner so the UI can honor multi-step envelopes

## Testing
- not run (extension has no automated tests)

------
https://chatgpt.com/codex/tasks/task_b_68c8c01a43c4832989ffab164a6766fe